### PR TITLE
Dispose of SharedEditor and SharedBuffer when disposing of GuestPortal

### DIFF
--- a/lib/shared-buffer.js
+++ b/lib/shared-buffer.js
@@ -21,8 +21,8 @@ class SharedBuffer {
     this.inbox = new FragmentInbox()
   }
 
-  async dispose () {
-    if (this.subscription) await this.subscription.dispose()
+  dispose () {
+    if (this.subscription) this.subscription.dispose()
   }
 
   async create ({uri, text}) {

--- a/lib/shared-editor.js
+++ b/lib/shared-editor.js
@@ -16,9 +16,9 @@ class SharedEditor {
     this.selectionMarkerLayersBySiteId = {}
   }
 
-  async dispose () {
-    if (this.subscription) await this.subscription.dispose()
-    if (this.sharedBuffer) await this.sharedBuffer.dispose()
+  dispose () {
+    if (this.subscription) this.subscription.dispose()
+    if (this.sharedBuffer) this.sharedBuffer.dispose()
   }
 
   async create ({sharedBuffer, selectionRanges}) {


### PR DESCRIPTION
While working on https://github.com/atom/real-time/pull/26, I found a few places where we need to improve our resource disposal. https://github.com/atom/real-time/pull/26 depends on the changes in this PR.