### PR TITLE
Disconnect when ice connection state becomes 'closed'

### DIFF
--- a/lib/peer-connection.js
+++ b/lib/peer-connection.js
@@ -70,7 +70,9 @@ class PeerConnection {
     // inform the remaining peers of the disconnection as each peer leaves.
     process.nextTick(() => {
       if (this.channel) this.channel.close()
-      this.rtcPeerConnection.close()
+      if (this.rtcPeerConnection.iceConnectionState !== 'closed') {
+        this.rtcPeerConnection.close()
+      }
     })
   }
 
@@ -82,9 +84,11 @@ class PeerConnection {
       this.resolveConnectedPromise()
     }
 
-    if (iceConnectionState === 'disconnected' && signalingState === 'stable') {
-      this.disconnect()
-    }
+    const hasDisconnected = (
+      iceConnectionState === 'closed' ||
+      (iceConnectionState === 'disconnected' && signalingState === 'stable')
+    )
+    if (hasDisconnected) this.disconnect()
   }
 
   async handleNegotiationNeeded () {


### PR DESCRIPTION
Fixes https://github.com/atom/real-time/issues/41.

Previously, we would detect a connection as closed only when its state became `disconnected`. However, when a connection terminates abruptly (e.g. when the OS goes into sleep mode and/or the network card is turned off) Chromium puts the `iceConnectionState` straight into `closed` mode.

With this commit we are adding handling for the `closed` connection state, which addresses the `Failed to execute 'send'` exception we were observing.

I am not sure testing this behavior is feasible with simple unit tests, so I believe we should defer this to the QA phase for now. If we find this code path to be frequently subject to regressions, I think
investing more time on writing a more sophisticated integration test could be justifiable.

/cc: @nathansobo @jasonrudolph @ungb 