### PR TITLE
Teach RestGateway to cache responses

### DIFF
--- a/lib/peer-pool.js
+++ b/lib/peer-pool.js
@@ -16,25 +16,14 @@ class PeerPool {
 
   initialize () {
     return Promise.all([
-      this.getICEServers(),
+      this.fetchICEServers(),
       this.waitForIncomingSignals()
     ])
   }
 
-  async getICEServers () {
-    if (this.iceServers == null) {
-      const {body, ok, headers} = await this.restGateway.get(`/ice-servers`)
-      this.iceServers = body
-
-      const expirationTimestamp = headers.get('Expires')
-      if (expirationTimestamp) {
-        const expirationDate = new Date(expirationTimestamp)
-        const ttl = expirationDate - Date.now()
-        // TODO Clear this timeout when we destroy a PeerPool object
-        setTimeout(() => {this.iceServers = null}, ttl)
-      }
-    }
-    return this.iceServers
+  async fetchICEServers () {
+    const {body, ok} = await this.restGateway.get(`/ice-servers`)
+    this.iceServers = body
   }
 
   waitForIncomingSignals () {

--- a/lib/rest-gateway.js
+++ b/lib/rest-gateway.js
@@ -4,25 +4,38 @@ module.exports =
 class RestGateway {
   constructor ({baseURL}) {
     this.baseURL = baseURL
+    this.cache = new Map()
   }
 
   async get (relativeURL) {
+    const cachedResults = this.cache.get(relativeURL)
+    if (cachedResults) {
+      return {body: cachedResults, ok: true}
+    }
+
     const url = new URL(relativeURL, this.baseURL).toString()
-    const response = await window.fetch(url, {
+    const response = await this.fetch(url, {
       method: 'GET',
       headers: {'Accept': 'application/json'}
     })
 
-    return {
-      body: await response.json(),
-      ok: response.ok,
-      headers: response.headers
+    const body = await response.json()
+
+    const expirationTimestamp = response.headers.get('Expires')
+    if (expirationTimestamp) {
+      this.cache.set(relativeURL, body)
+
+      const expirationDate = new Date(expirationTimestamp)
+      const ttl = expirationDate - Date.now()
+      this.setTimeout(() => {this.cache.delete(relativeURL)}, ttl) // TODO Clear this timeout when we destroy a RestGateway object
     }
+
+    return {body, ok: response.ok}
   }
 
   async post (relativeURL, body) {
     const url = new URL(relativeURL, this.baseURL).toString()
-    const response = await window.fetch(url, {
+    const response = await this.fetch(url, {
       method: 'POST',
       headers: {
         'Accept': 'application/json',
@@ -33,8 +46,15 @@ class RestGateway {
 
     return {
       body: await response.json(),
-      ok: response.ok,
-      headers: response.headers
+      ok: response.ok
     }
+  }
+
+  fetch (input, init) {
+    return window.fetch(input, init)
+  }
+
+  setTimeout (callback, delay) {
+    return window.setTimeout(callback, delay)
   }
 }

--- a/test/peer-pool.test.js
+++ b/test/peer-pool.test.js
@@ -74,39 +74,4 @@ suite('PeerPool', () => {
     assert.deepEqual(peer2Pool.testDisconnectionEvents, ['3'])
     assert.deepEqual(peer3Pool.testDisconnectionEvents, ['2', '1'])
   })
-
-  test('fetching and caching ICE servers', async () => {
-    const servers = [
-      {
-        url: 'some-url',
-        username: 'some-username',
-        credential: 'some-credential'
-      }
-    ]
-
-    let apiRequestCount = 0
-    const stubRestGateway = {
-      get: async function (url) {
-        apiRequestCount++
-        const headers = new Headers({
-          'Expires': new Date(Date.now() + 100).toUTCString()
-        })
-        return {
-          body: servers,
-          ok: true,
-          headers
-        }
-      }
-    }
-
-    const peerPool = new PeerPool({restGateway: stubRestGateway})
-
-    // initial request fetches ICE servers from Rest API
-    assert.deepEqual(await peerPool.getICEServers(), servers)
-    assert.equal(apiRequestCount, 1)
-
-    // subsequent requests fetch ICE servers from cache
-    assert.deepEqual(await peerPool.getICEServers(), servers)
-    assert.equal(apiRequestCount, 1)
-  })
 })

--- a/test/rest-gateway.test.js
+++ b/test/rest-gateway.test.js
@@ -1,0 +1,67 @@
+const assert = require('assert')
+
+const RestGateway = require('../lib/rest-gateway')
+
+suite('RestGateway', () => {
+  test("cache responses for the duration specified by the 'Expires' header", async () => {
+    const gateway = new RestGateway({baseURL: 'http://example.com'})
+
+    let requestCount = 0
+    gateway.fetch = (input, init) => {
+      requestCount++
+
+      let body
+      switch (input) {
+        case 'http://example.com/a':
+          body = {a: 'a'}
+          break;
+        case 'http://example.com/b':
+          body = {b: 'b'}
+          break;
+      }
+
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: {
+          'Expires': new Date(Date.now() + 60000).toUTCString(),
+          'Content-Type': 'application/json'
+        }
+      })
+    }
+
+    const callbacks = []
+    gateway.setTimeout = (callback, delay) => {
+      callbacks.push({callback, delay})
+    }
+
+    let response = await gateway.get('/a')
+    assert.equal(requestCount, 1)
+    assert.equal(callbacks.length, 1)
+    assert.deepEqual(response.body, {a: 'a'})
+
+    response = await gateway.get('/b')
+    assert.equal(requestCount, 2)
+    assert.equal(callbacks.length, 2)
+    assert.deepEqual(response.body, {b: 'b'})
+
+    response = await gateway.get('/a')
+    assert.equal(requestCount, 2)
+    assert.equal(callbacks.length, 2)
+    assert.deepEqual(response.body, {a: 'a'})
+
+    response = await gateway.get('/b')
+    assert.equal(requestCount, 2)
+    assert.equal(callbacks.length, 2)
+    assert.deepEqual(response.body, {b: 'b'})
+
+    callbacks.forEach(({delay}) => {
+      assert(delay > 59000 && delay < 61000, `TTL of ${delay} is outside of the expected threshold`)
+    })
+
+    callbacks.forEach(({callback}) => callback())
+    response = await gateway.get('/a')
+    assert.equal(requestCount, 3)
+    assert.equal(callbacks.length, 3)
+    assert.deepEqual(response.body, {a: 'a'})
+  })
+})


### PR DESCRIPTION
We originally thought that we'd need update real-time-client to cache the ICE server URLs and credentials that it fetches from the server (https://github.com/atom/real-time-server/pull/10). This PR implements that caching. I now realize that we don't need this caching after all. (See explanation below.) Just in case we discover a future need caching in `RestGateway`, I'm capturing this work in a PR so that we can easily find it later. But, since we don't need it at the moment, I'll immediately close this PR. 😇 

---

After implementing the caching in this PR, I noticed that we don't need it after all. Instead, Electron automatically respects the caching headers introduced in https://github.com/atom/real-time-server/pull/10. :sweat_smile: Each time the client calls `window.fetch` to make a `GET /ice-servers` request, Electron first checks to see if it already has a cached response that is still valid. If so, Electron returns that response without contacting the real-time server. If not, Electron makes the request to the server and caches the response for the duration specified in the response's caching headers.

In the screenshot below, I had my local real-time-server set a 30-second TTL for responses from `GET /ice-servers`. Then, I told Atom to make a `GET /ice-servers` request via `window.fetch` every 5 seconds. We can see that responses are returned from the cache until the cache expires after 30 seconds. We get that behavior for free _without_ the changes in this PR.

![screenshot](https://user-images.githubusercontent.com/2988/30606650-5f522288-9d40-11e7-93ce-3c9db1458db7.png)
