### PR TITLE
Fix infinite loop in `RealTimeClient.authenticate`

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -10,7 +10,7 @@ class NetworkConnectionError extends Error {
   }
 }
 
-class InvalidAuthTokenError extends Error {
+class AuthenticationError extends Error {
   constructor () {
     super(...arguments)
   }
@@ -49,7 +49,7 @@ class PubSubConnectionError extends Error {
 module.exports = {
   ClientOutOfDateError,
   NetworkConnectionError,
-  InvalidAuthTokenError,
+  AuthenticationError,
   PeerConnectionError,
   PortalCreationError,
   PortalJoinError,

--- a/lib/pub-sub-signaling-provider.js
+++ b/lib/pub-sub-signaling-provider.js
@@ -26,10 +26,10 @@ class PubSubSignalingProvider {
       const {status} = await this.restGateway.post(`/peers/${this.remotePeerId}/signals`, body)
       if (status === 401) {
         this.authTokenProvider.didInvalidateToken()
-        throw new Errors.InvalidAuthTokenError('The provided authentication token is invalid')
+        throw new Errors.AuthenticationError('The provided authentication token is invalid')
       }
     } else {
-      throw new Errors.InvalidAuthTokenError('No token available to authenticate connection')
+      throw new Errors.AuthenticationError('No token available to authenticate connection')
     }
   }
 

--- a/lib/real-time-client.js
+++ b/lib/real-time-client.js
@@ -120,7 +120,7 @@ class RealTimeClient {
         } else if (status === 401) {
           this.authTokenProvider.didInvalidateToken()
         } else {
-          // TODO: Throw error
+          throw new Errors.AuthenticationError('Authentication failed with message: ' + body.message)
         }
       } else {
         return false

--- a/test/peer-pool.test.js
+++ b/test/peer-pool.test.js
@@ -160,7 +160,7 @@ suite('PeerPool', () => {
       } catch (e) {
         error = e
       }
-      assert(error instanceof Errors.InvalidAuthTokenError)
+      assert(error instanceof Errors.AuthenticationError)
       assert.equal(peer2Pool.authTokenProvider.authToken, null)
       peer2Pool.authTokenProvider.authToken = '2-token'
     }
@@ -175,7 +175,7 @@ suite('PeerPool', () => {
       }
       assert(error instanceof Errors.PeerConnectionError)
       assert.equal(peer2Pool.testErrors.length, 1)
-      assert(peer2Pool.testErrors[0] instanceof Errors.InvalidAuthTokenError)
+      assert(peer2Pool.testErrors[0] instanceof Errors.AuthenticationError)
       assert.equal(peer2Pool.authTokenProvider.authToken, null)
       peer2Pool.authTokenProvider.authToken = '2-token'
     }


### PR DESCRIPTION
Back in #18 we forgot to handle the scenario where the server responds with a non-401 error, which could cause `real-time-client` to continuously prompt the user for new tokens even if the server can't handle authentication requests. This pull-request takes care of throwing an error when that happens and also introduces two unit tests to verify the interaction with `AuthTokenProvider`.

/cc: @nathansobo @jasonrudolph 