### PR TITLE
Teach PeerPool to throw error when attempting to connect to yourself

### DIFF
--- a/lib/peer-pool.js
+++ b/lib/peer-pool.js
@@ -60,6 +60,10 @@ class PeerPool {
   }
 
   async connectTo (peerId) {
+    if (this.peerId === peerId) {
+      throw new Errors.PeerConnectionError('Sorry. You can\'t connect to yourself this way. Maybe try meditation or a walk in the woods instead?')
+    }
+
     const peerConnection = this.getPeerConnection(peerId)
 
     try {

--- a/test/peer-pool.test.js
+++ b/test/peer-pool.test.js
@@ -218,6 +218,18 @@ suite('PeerPool', () => {
     await peer2Pool.getConnectedPromise('1')
   })
 
+  test('attempting to connect to yourself', async () => {
+    const peerPool = await buildPeerPool('1', server)
+
+    let error
+    try {
+      await peerPool.connectTo('1')
+    } catch (e) {
+      error = e
+    }
+    assert(error instanceof Errors.PeerConnectionError)
+  })
+
   test('RTCPeerConnection and RTCDataChannel error events', async () => {
     const peer1Pool = await buildPeerPool('1', server)
     const peer2Pool = await buildPeerPool('2', server)


### PR DESCRIPTION
In https://github.com/atom/real-time/pull/97, we need a way to gracefully handle the exception that occurs when you attempt to join your own portal. This PR teaches `PeerPool::connectTo(peerId)` to throw an error if you attempt to connect to yourself.

### Before

![screen shot 2017-10-06 at 3 03 38 pm](https://user-images.githubusercontent.com/2988/31294133-c0dbbfc2-aaa7-11e7-8251-eb3597e3d392.png)

### After

![screen shot 2017-10-06 at 3 01 19 pm](https://user-images.githubusercontent.com/2988/31294134-c0df0cae-aaa7-11e7-8956-50e76f5366ed.png)
