### PR TITLE
Mark `StarOverlayNetwork` as disconnected if `connectTo` throws an error

### DIFF
--- a/lib/star-overlay-network.js
+++ b/lib/star-overlay-network.js
@@ -44,12 +44,18 @@ class StarOverlayNetwork {
     this.hubId = hubId
     await this.peerPool.connectTo(this.hubId)
 
-    const starJoinRequest = new NetworkMessage.StarJoinRequest()
-    starJoinRequest.setSenderId(this.getPeerId())
-    const networkMessage = new NetworkMessage()
-    networkMessage.setStarJoinRequest(starJoinRequest)
-    networkMessage.setNetworkId(this.id)
-    this.send(this.hubId, networkMessage.serializeBinary())
+    try {
+      const starJoinRequest = new NetworkMessage.StarJoinRequest()
+      starJoinRequest.setSenderId(this.getPeerId())
+      const networkMessage = new NetworkMessage()
+      networkMessage.setStarJoinRequest(starJoinRequest)
+      networkMessage.setNetworkId(this.id)
+      this.send(this.hubId, networkMessage.serializeBinary())
+    } catch (error) {
+      this.state = 'disconnected'
+      this.hubId = null
+      throw error
+    }
 
     const timeoutError = new Errors.NetworkConnectionError('Connecting to the portal network timed out')
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
When joining a portal throws an error, we automatically dispose the `Portal` instance and disconnect from its associated `StarOverlayNetwork`. Previously, however, if the error was generated while connecting to the star overlay network, we could trigger exceptions like the one reported in https://github.com/atom/real-time/issues/103.

In fact, disconnecting from a network while a connection was still in progress would deliver a disconnection message to the hub which, in turn, would emit a "leave" event. When handling such event (like we do in `HostPortalBinding.siteDidLeave`), users of this API could attempt to get information regarding the identity of the client, which the `StarOverlayNetwork` may not have due to the unsuccessful initial connection handshake.

With this pull-request, if we encounter any error when sending the initial connection message in `StarOverlayNetwork.connectTo`, we will put the overlay network back into a `disconnected` state, causing future calls to `disconnect` to simply be no-ops.

/cc: @nathansobo @jasonrudolph 