### PR TITLE
Process portal updates in the same order that they arrive in

### DIFF
--- a/lib/portal.js
+++ b/lib/portal.js
@@ -22,6 +22,7 @@ class Portal {
     this.disposables = new CompositeDisposable()
     this.disposed = false
     this.delegate = new NullPortalDelegate()
+    this.lastReceiveUpdatePromise = Promise.resolve()
 
     this.peerPool = peerPool
     this.network = new StarOverlayNetwork({id, isHub: this.isHost, peerPool, connectionTimeout})
@@ -225,15 +226,17 @@ class Portal {
   }
 
   receiveUpdate ({message}) {
-    const updateMessage = Messages.PortalUpdate.deserializeBinary(message)
+    this.lastReceiveUpdatePromise = this.lastReceiveUpdatePromise.then(async () => {
+      const updateMessage = Messages.PortalUpdate.deserializeBinary(message)
 
-    if (updateMessage.hasEditorProxySwitch()) {
-      this.receiveEditorProxySwitch(updateMessage.getEditorProxySwitch())
-    } else if (updateMessage.hasSiteAssignment()) {
-      this.receiveSiteAssignment(updateMessage.getSiteAssignment())
-    } else {
-      throw new Error('Received unknown update message')
-    }
+      if (updateMessage.hasEditorProxySwitch()) {
+        await this.receiveEditorProxySwitch(updateMessage.getEditorProxySwitch())
+      } else if (updateMessage.hasSiteAssignment()) {
+        this.receiveSiteAssignment(updateMessage.getSiteAssignment())
+      } else {
+        throw new Error('Received unknown update message')
+      }
+    })
   }
 
   async receiveEditorProxySwitch (editorProxySwitch) {


### PR DESCRIPTION
Previously, when receiving an update on the guest `Portal` entity, a race condition could occur when switching the active editor proxy. This could happen when guests received a request to switch to an editor proxy that they hadn't seen yet and then immediately received another request to switch back to some editor proxy they had already observed. If the second request arrived while fetching the state of the new editor and buffer proxies, real-time-client would have honored it first, thus causing updates to be processed in the wrong order.

This pull-request fixes the race condition by making sure that every new update is processed only *after* prior updates have been completely digested, which should fix the exception @nathansobo and I were observing yesterday while pairing.

/cc: @jasonrudolph @nathansobo 