### PR TITLE
Toggle selections when tether changes after integrating remote tether updates

### DIFF
--- a/lib/editor-proxy.js
+++ b/lib/editor-proxy.js
@@ -358,20 +358,28 @@ class EditorProxy {
   }
 
   receiveTetherUpdate (tetherUpdate) {
-    const oldResolvedLeaderSiteId = this.resolveLeaderSiteId()
+    const oldResolvedLeaderId = this.resolveLeaderSiteId()
+    const oldResolvedState = this.resolveFollowState()
+    const wasRetracted = oldResolvedState === FollowState.RETRACTED
+
     const followerSiteId = tetherUpdate.getFollowerSiteId()
     const leaderSiteId = tetherUpdate.getLeaderSiteId()
     const tetherState = tetherUpdate.getState()
-
     this.tethersByFollowerId.set(followerSiteId, {leaderId: leaderSiteId, state: tetherState})
 
-    this.updateActivePositions()
-    if (this.resolveLeaderSiteId() !== oldResolvedLeaderSiteId) {
-      const leaderPosition = this.resolveLeaderPosition()
-      if (leaderPosition) {
-        this.delegate.updateTether(this.resolveFollowState(), leaderPosition)
-      }
+    const newResolvedLeaderId = this.resolveLeaderSiteId()
+    const newResolvedState = this.resolveFollowState()
+    const isRetracted = newResolvedState === FollowState.RETRACTED
+
+    if (wasRetracted !== isRetracted) {
+      this.updateSelections(this.getLocalHiddenSelections(), true)
     }
+
+    if (newResolvedLeaderId !== oldResolvedLeaderId) {
+      this.delegate.updateTether(newResolvedState, this.resolveLeaderPosition())
+    }
+
+    this.updateActivePositions()
   }
 }
 

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -519,6 +519,19 @@ suite('Client Integration', () => {
       guest2EditorDelegate.updateViewport(5, 15)
       guest2EditorProxy.setDelegate(guest2EditorDelegate)
 
+      // Disconnect guest1's tether.
+      guest1EditorProxy.unfollow()
+      guest1EditorProxy.updateSelections({1: {range: range([0, 0], [0, 0])}})
+
+      await condition(() => {
+        const guest1SelectionOnHost = hostEditorDelegate.getSelectionsForSiteId(guest1Portal.siteId)[1]
+        const guest1SelectionOnGuest2 = guest2EditorDelegate.getSelectionsForSiteId(guest1Portal.siteId)[1]
+        return (
+          guest1SelectionOnHost && deepEqual(guest1SelectionOnHost.range, range([0, 0], [0, 0])) &&
+          guest1SelectionOnGuest2 && deepEqual(guest1SelectionOnGuest2.range, range([0, 0], [0, 0]))
+        )
+      })
+
       // Form a cycle (guest1 -> guest2 -> host -> guest1) and ensure it gets
       // broken on the site with the lowest site id.
       guest1EditorProxy.follow(guest2Portal.siteId)


### PR DESCRIPTION
This is necessary because the tether of the site with the lowest id could be retracted. If another site changes their tether and introduces a cycle, we need to un-retract the tether of the new leader (i.e. the site with the lowest id) and propagate its position to all the new followers.

/cc: @nathansobo @jasonrudolph 