### PR TITLE
Fix "Failed to execute send on RTCDataChannel" exception

### DIFF
--- a/lib/peer-connection.js
+++ b/lib/peer-connection.js
@@ -126,10 +126,7 @@ class PeerConnection {
     if (this.channel.readyState === 'open') {
       this.handleConnectionStateChange()
     } else {
-      this.channel.onopen = () => {
-        this.channel.onopen = null
-        this.handleConnectionStateChange()
-      }
+      this.channel.onopen = this.handleConnectionStateChange.bind(this)
     }
   }
 


### PR DESCRIPTION
After observing an elevated amount of `Uncaught NetworkError: Failed to execute 'send' on 'RTCDataChannel': Could not send data` errors on Travis CI (and on the teletype package too, see https://github.com/atom/teletype/issues/132), I decided to investigate the cause of this issue.

Considering I could reproduce this 40% of the time on Travis, I added some logging statements to verify the state of the WebRTC connection at the moment of the error. Thanks to these, I discovered that the [`RTCDataChannel.readyState`](https://developer.mozilla.org/en-US/docs/Web/API/RTCDataChannel/readyState) was sometimes `connecting` (as opposed to `open`) when we called `PeerConnection.send`.

Upon further investigation, it looks like establishing a data channel between two peers could happen *after* a connection between them has already been established. Thus, with this pull-request, we will wait until both the connection and the data channel are ready for transmission before resolving the "connected promise" of the `PeerConnection`s.

I confirmed that, after this change, the reproduce rate went from 40% to 0% on Travis CI.

/cc: @nathansobo @jasonrudolph 