### PR TITLE
Download teletype-server and teletype-crdt from NPM registry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,15 +5,17 @@
   "requires": true,
   "dependencies": {
     "@atom/teletype-crdt": {
-      "version": "https://user-with-just-readonly-access-to-realtime-repos:924792417376b236ca11cc234bcc95d306dcd1cb@api.github.com/repos/atom/teletype-crdt/tarball/v0.8.0",
-      "integrity": "sha1-/89nZuxpkuNoBZDvLLXBqv+Vyt8=",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@atom/teletype-crdt/-/teletype-crdt-0.8.0.tgz",
+      "integrity": "sha512-xRAN6DhuxdL8s9KN7unxiw9O03Wc9vZh/UoetaFKHHu3wjDiNhRrh5vqVnfcaLNsuGbHfYbfmxAX1l0uVp9mlg==",
       "requires": {
         "google-protobuf": "3.4.0"
       }
     },
     "@atom/teletype-server": {
-      "version": "https://user-with-just-readonly-access-to-realtime-repos:924792417376b236ca11cc234bcc95d306dcd1cb@api.github.com/repos/atom/teletype-server/tarball/v0.16.0",
-      "integrity": "sha1-8wEf3kMTgwOtm4l7Ys9xXVHa4w0=",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@atom/teletype-server/-/teletype-server-0.16.0.tgz",
+      "integrity": "sha512-J3rSmzY2ASF/PWhYu3bpXD/BqvoP0lJjUxuHEGnXpn5B1YMUzbtfbvQjt6a0CA3vKleWe1h2awasaVIsJNwTZQ==",
       "dev": true,
       "requires": {
         "body-parser": "1.18.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@atom/teletype-crdt": "https://user-with-just-readonly-access-to-realtime-repos:924792417376b236ca11cc234bcc95d306dcd1cb@api.github.com/repos/atom/teletype-crdt/tarball/v0.8.0",
+    "@atom/teletype-crdt": "^0.8.0",
     "event-kit": "^2.3.0",
     "google-protobuf": "^3.4.0",
     "pusher-js": "^4.1.0",
@@ -18,7 +18,7 @@
     "webrtc-adapter": "^4.2.1"
   },
   "devDependencies": {
-    "@atom/teletype-server": "https://user-with-just-readonly-access-to-realtime-repos:924792417376b236ca11cc234bcc95d306dcd1cb@api.github.com/repos/atom/teletype-server/tarball/v0.16.0",
+    "@atom/teletype-server": "^0.16.0",
     "deep-equal": "^1.0.1",
     "dotenv": "^4.0.0",
     "electron": "1.6.11",


### PR DESCRIPTION
This pull-request should be merged the day of launch after addressing the following tasks:

* [x] Make @atom/teletype-server public on npmjs.com.
* [x] Make @atom/teletype-crdt public on npmjs.com.
* [x] Restart CI build to ensure it is green.
* [x] Merge this pull-request.
* [x] Bump version and publish a new version of the teletype-client module.

/cc: @nathansobo @jasonrudolph 