### PR TITLE
Supported Pusher options

### DIFF
--- a/lib/pusher-pub-sub-gateway.js
+++ b/lib/pusher-pub-sub-gateway.js
@@ -4,10 +4,10 @@ const Errors = require('./errors')
 
 module.exports =
 class PusherPubSubGateway {
-  constructor ({key}) {
+  constructor ({key, options}) {
     this.channelsByName = new Map()
     this.subscriptionsCount = 0
-    this.pusherClient = createDisconnectedPusherClient(key)
+    this.pusherClient = createDisconnectedPusherClient(key, options)
   }
 
   async subscribe (channelName, eventName, callback) {
@@ -65,8 +65,12 @@ class PusherPubSubGateway {
   }
 }
 
-function createDisconnectedPusherClient (key) {
-  const client = new Pusher(key, {encrypted: true}) // automatically connects to pusher
+function createDisconnectedPusherClient (key, options) {
+  const connectOptions = Object.assign({
+    encrypted: true,
+  }, options)
+
+  const client = new Pusher(key, connectOptions) // automatically connects to pusher
   client.disconnect()
   return client
 }

--- a/lib/teletype-client.js
+++ b/lib/teletype-client.js
@@ -13,9 +13,9 @@ const LOCAL_PROTOCOL_VERSION = 4
 
 module.exports =
 class TeletypeClient {
-  constructor ({restGateway, pubSubGateway, connectionTimeout, tetherDisconnectWindow, testEpoch, pusherKey, baseURL, didCreateOrJoinPortal}) {
+  constructor ({restGateway, pubSubGateway, connectionTimeout, tetherDisconnectWindow, testEpoch, pusherKey, pusherOptions, baseURL, didCreateOrJoinPortal}) {
     this.restGateway = restGateway || new RestGateway({baseURL})
-    this.pubSubGateway = pubSubGateway || new PusherPubSubGateway({key: pusherKey})
+    this.pubSubGateway = pubSubGateway || new PusherPubSubGateway({key: pusherKey, options: pusherOptions})
     this.connectionTimeout = connectionTimeout || 5000
     this.tetherDisconnectWindow = tetherDisconnectWindow || DEFAULT_TETHER_DISCONNECT_WINDOW
     this.testEpoch = testEpoch


### PR DESCRIPTION
I use Pusher in EU cluster and I get this error message:

```
{"type":"WebSocketError","error":{"type":"PusherError","data":{"code":4001,"message":"Did you forget to specify the cluster when creating the Pusher instance?  App key XYZ does not exist in this cluster."}}}
```

This PR can be parameterized by the constructor.