### PR TITLE
Use browser version of the pusher-js module

### DIFF
--- a/lib/pusher-pub-sub-gateway.js
+++ b/lib/pusher-pub-sub-gateway.js
@@ -1,4 +1,4 @@
-const Pusher = require('pusher-js')
+const Pusher = require('pusher-js/dist/web/pusher')
 const {Disposable} = require('event-kit')
 const Errors = require('./errors')
 


### PR DESCRIPTION
Refs: https://github.com/atom/teletype/issues/192

The Pusher client library comes in different flavors, one for each environment (e.g. web, service workers, node, etc.). Requiring the `pusher-js` module loads the Node version of the library, which uses third-party modules like `faye` or `xmlhttprequest` to add support for web sockets and `XMLHttpRequest` into Node. These modules are known to require additional configuration to support system proxy settings and, while they make a lot of sense in a Node-only environment, teletype-client is meant to be run in a browser context like Electron or a simple web page.

With this pull request we will use the browser version of the Pusher client instead. By using Chromium primitives like `WebSocket` and `XMLHttpRequest` we are hoping to solve the network issues experienced by some users who are attempting to use teletype behind a proxy. These users have reported that using `fetch` to create portals works fine for them, so we are speculating that relying on browser primitives also for signaling will solve their connectivity issues.

/cc: @nathansobo @jasonrudolph 