### PR TITLE
⬆️ teletype-server@0.17.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,9 @@
       }
     },
     "@atom/teletype-server": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@atom/teletype-server/-/teletype-server-0.16.0.tgz",
-      "integrity": "sha512-J3rSmzY2ASF/PWhYu3bpXD/BqvoP0lJjUxuHEGnXpn5B1YMUzbtfbvQjt6a0CA3vKleWe1h2awasaVIsJNwTZQ==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@atom/teletype-server/-/teletype-server-0.17.0.tgz",
+      "integrity": "sha512-2b+1AuJx2K00xiyjeoCgHWbPY3PV/ofoHtMSpojJ4+g0KqAKATLiJaCuef5y8dT2OGw8GHRsjE+IVzCxGocf0w==",
       "dev": true,
       "requires": {
         "body-parser": "1.18.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "webrtc-adapter": "^4.2.1"
   },
   "devDependencies": {
-    "@atom/teletype-server": "^0.16.0",
+    "@atom/teletype-server": "^0.17.0",
     "deep-equal": "^1.0.1",
     "dotenv": "^4.0.0",
     "electron": "1.6.11",

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -923,7 +923,7 @@ suite('Client Integration', () => {
 
       assert(await client.signIn('token-1'))
       assert(client.isSignedIn())
-      assert.deepEqual(client.getLocalUserIdentity(), {login: 'user-1'})
+      assert.equal(client.getLocalUserIdentity().login, 'user-1')
       assert.equal(client.testSignInChangeEvents.length, 1)
       assert(!client.peerPool.disposed)
 
@@ -936,7 +936,7 @@ suite('Client Integration', () => {
 
       assert(await client.signIn('token-2'))
       assert(client.isSignedIn())
-      assert.deepEqual(client.getLocalUserIdentity(), {login: 'user-2'})
+      assert.equal(client.getLocalUserIdentity().login, 'user-2')
       assert.equal(client.testSignInChangeEvents.length, 3)
       assert(!client.peerPool.disposed)
     })

--- a/test/peer-pool.test.js
+++ b/test/peer-pool.test.js
@@ -34,9 +34,9 @@ suite('PeerPool', () => {
     const peer3Pool = await buildPeerPool('3', server)
 
     // Local peer identities
-    assert.deepEqual(peer1Pool.getLocalPeerIdentity(), {login: 'user-with-token-1-token'})
-    assert.deepEqual(peer2Pool.getLocalPeerIdentity(), {login: 'user-with-token-2-token'})
-    assert.deepEqual(peer3Pool.getLocalPeerIdentity(), {login: 'user-with-token-3-token'})
+    assert.equal(peer1Pool.getLocalPeerIdentity().login, 'user-with-token-1-token')
+    assert.equal(peer2Pool.getLocalPeerIdentity().login, 'user-with-token-2-token')
+    assert.equal(peer3Pool.getLocalPeerIdentity().login, 'user-with-token-3-token')
 
     // Connection
     await peer1Pool.connectTo('3')
@@ -48,10 +48,10 @@ suite('PeerPool', () => {
     await peer3Pool.getConnectedPromise('2')
 
     // Remote peer identities
-    assert.deepEqual(peer1Pool.getPeerIdentity('3'), {login: 'user-with-token-3-token'})
-    assert.deepEqual(peer3Pool.getPeerIdentity('1'), {login: 'user-with-token-1-token'})
-    assert.deepEqual(peer2Pool.getPeerIdentity('3'), {login: 'user-with-token-3-token'})
-    assert.deepEqual(peer3Pool.getPeerIdentity('2'), {login: 'user-with-token-2-token'})
+    assert.equal(peer1Pool.getPeerIdentity('3').login, 'user-with-token-3-token')
+    assert.equal(peer3Pool.getPeerIdentity('1').login, 'user-with-token-1-token')
+    assert.equal(peer2Pool.getPeerIdentity('3').login, 'user-with-token-3-token')
+    assert.equal(peer3Pool.getPeerIdentity('2').login, 'user-with-token-2-token')
 
     // Single-part messages
     peer1Pool.send('3', Buffer.from('a'))
@@ -88,15 +88,15 @@ suite('PeerPool', () => {
     assert.deepEqual(peer3Pool.testDisconnectionEvents, ['2', '1'])
 
     // Retain local peer identities after disconnecting
-    assert.deepEqual(peer1Pool.getLocalPeerIdentity(), {login: 'user-with-token-1-token'})
-    assert.deepEqual(peer2Pool.getLocalPeerIdentity(), {login: 'user-with-token-2-token'})
-    assert.deepEqual(peer3Pool.getLocalPeerIdentity(), {login: 'user-with-token-3-token'})
+    assert.equal(peer1Pool.getLocalPeerIdentity().login, 'user-with-token-1-token')
+    assert.equal(peer2Pool.getLocalPeerIdentity().login, 'user-with-token-2-token')
+    assert.equal(peer3Pool.getLocalPeerIdentity().login, 'user-with-token-3-token')
 
     // Retain remote peer identities after disconnecting
-    assert.deepEqual(peer1Pool.getPeerIdentity('3'), {login: 'user-with-token-3-token'})
-    assert.deepEqual(peer3Pool.getPeerIdentity('1'), {login: 'user-with-token-1-token'})
-    assert.deepEqual(peer2Pool.getPeerIdentity('3'), {login: 'user-with-token-3-token'})
-    assert.deepEqual(peer3Pool.getPeerIdentity('2'), {login: 'user-with-token-2-token'})
+    assert.equal(peer1Pool.getPeerIdentity('3').login, 'user-with-token-3-token')
+    assert.equal(peer3Pool.getPeerIdentity('1').login, 'user-with-token-1-token')
+    assert.equal(peer2Pool.getPeerIdentity('3').login, 'user-with-token-3-token')
+    assert.equal(peer3Pool.getPeerIdentity('2').login, 'user-with-token-2-token')
   })
 
   test('timeouts connecting to the pub-sub service', async () => {

--- a/test/portal.test.js
+++ b/test/portal.test.js
@@ -110,17 +110,17 @@ suite('Portal', () => {
     await guest1Portal.join()
     await guest2Portal.join()
 
-    assert.deepEqual(hostPortal.getSiteIdentity(1), hostIdentity)
-    assert.deepEqual(hostPortal.getSiteIdentity(2), guest1Identity)
-    assert.deepEqual(hostPortal.getSiteIdentity(3), guest2Identity)
+    assert.equal(hostPortal.getSiteIdentity(1).login, hostIdentity.login)
+    assert.equal(hostPortal.getSiteIdentity(2).login, guest1Identity.login)
+    assert.equal(hostPortal.getSiteIdentity(3).login, guest2Identity.login)
 
-    assert.deepEqual(guest1Portal.getSiteIdentity(1), hostIdentity)
-    assert.deepEqual(guest1Portal.getSiteIdentity(2), guest1Identity)
-    assert.deepEqual(guest1Portal.getSiteIdentity(3), guest2Identity)
+    assert.equal(guest1Portal.getSiteIdentity(1).login, hostIdentity.login)
+    assert.equal(guest1Portal.getSiteIdentity(2).login, guest1Identity.login)
+    assert.equal(guest1Portal.getSiteIdentity(3).login, guest2Identity.login)
 
-    assert.deepEqual(guest2Portal.getSiteIdentity(1), hostIdentity)
-    assert.deepEqual(guest2Portal.getSiteIdentity(2), guest1Identity)
-    assert.deepEqual(guest2Portal.getSiteIdentity(3), guest2Identity)
+    assert.equal(guest2Portal.getSiteIdentity(1).login, hostIdentity.login)
+    assert.equal(guest2Portal.getSiteIdentity(2).login, guest1Identity.login)
+    assert.equal(guest2Portal.getSiteIdentity(3).login, guest2Identity.login)
   })
 
   test('changing active editor proxy', async () => {

--- a/test/star-overlay-network.test.js
+++ b/test/star-overlay-network.test.js
@@ -249,17 +249,17 @@ suite('StarOverlayNetwork', () => {
         setEqual(spoke2.getMemberIds(), ['hub', 'spoke-1', 'spoke-2'])
       ))
 
-      assert.deepEqual(hub.getMemberIdentity('hub'), hubIdentity)
-      assert.deepEqual(hub.getMemberIdentity('spoke-1'), spoke1Identity)
-      assert.deepEqual(hub.getMemberIdentity('spoke-2'), spoke2Identity)
+      assert.equal(hub.getMemberIdentity('hub').login, hubIdentity.login)
+      assert.equal(hub.getMemberIdentity('spoke-1').login, spoke1Identity.login)
+      assert.equal(hub.getMemberIdentity('spoke-2').login, spoke2Identity.login)
 
-      assert.deepEqual(spoke1.getMemberIdentity('hub'), hubIdentity)
-      assert.deepEqual(spoke1.getMemberIdentity('spoke-1'), spoke1Identity)
-      assert.deepEqual(spoke1.getMemberIdentity('spoke-2'), spoke2Identity)
+      assert.equal(spoke1.getMemberIdentity('hub').login, hubIdentity.login)
+      assert.equal(spoke1.getMemberIdentity('spoke-1').login, spoke1Identity.login)
+      assert.equal(spoke1.getMemberIdentity('spoke-2').login, spoke2Identity.login)
 
-      assert.deepEqual(spoke2.getMemberIdentity('hub'), hubIdentity)
-      assert.deepEqual(spoke2.getMemberIdentity('spoke-1'), spoke1Identity)
-      assert.deepEqual(spoke2.getMemberIdentity('spoke-2'), spoke2Identity)
+      assert.equal(spoke2.getMemberIdentity('hub').login, hubIdentity.login)
+      assert.equal(spoke2.getMemberIdentity('spoke-1').login, spoke1Identity.login)
+      assert.equal(spoke2.getMemberIdentity('spoke-2').login, spoke2Identity.login)
 
       // Ensure peer identities can be retrieved on all spokes after disconnection.
       spoke1.disconnect()
@@ -269,17 +269,17 @@ suite('StarOverlayNetwork', () => {
         setEqual(spoke2.getMemberIds(), ['hub', 'spoke-2'])
       ))
 
-      assert.deepEqual(hub.getMemberIdentity('hub'), hubIdentity)
-      assert.deepEqual(hub.getMemberIdentity('spoke-1'), spoke1Identity)
-      assert.deepEqual(hub.getMemberIdentity('spoke-2'), spoke2Identity)
+      assert.equal(hub.getMemberIdentity('hub').login, hubIdentity.login)
+      assert.equal(hub.getMemberIdentity('spoke-1').login, spoke1Identity.login)
+      assert.equal(hub.getMemberIdentity('spoke-2').login, spoke2Identity.login)
 
-      assert.deepEqual(spoke1.getMemberIdentity('hub'), hubIdentity)
-      assert.deepEqual(spoke1.getMemberIdentity('spoke-1'), spoke1Identity)
-      assert.deepEqual(spoke1.getMemberIdentity('spoke-2'), spoke2Identity)
+      assert.equal(spoke1.getMemberIdentity('hub').login, hubIdentity.login)
+      assert.equal(spoke1.getMemberIdentity('spoke-1').login, spoke1Identity.login)
+      assert.equal(spoke1.getMemberIdentity('spoke-2').login, spoke2Identity.login)
 
-      assert.deepEqual(spoke2.getMemberIdentity('hub'), hubIdentity)
-      assert.deepEqual(spoke2.getMemberIdentity('spoke-1'), spoke1Identity)
-      assert.deepEqual(spoke2.getMemberIdentity('spoke-2'), spoke2Identity)
+      assert.equal(spoke2.getMemberIdentity('hub').login, hubIdentity.login)
+      assert.equal(spoke2.getMemberIdentity('spoke-1').login, spoke1Identity.login)
+      assert.equal(spoke2.getMemberIdentity('spoke-2').login, spoke2Identity.login)
     })
   })
 


### PR DESCRIPTION
### Changes

- Upgrade to teletype-server@0.17.0
- Update tests for compatibility with teletype-server@0.17.0

  After upgrading to teletype-server@v0.17.0, [several identity-related tests began failing](https://travis-ci.org/atom/teletype-client/builds/304899268#L1079) because they expected the identity object to only contain a `login` property, and they didn't expect the inclusion of the [new `id` property](https://github.com/atom/teletype-server/pull/28/files#diff-073738e0497d0d53d062fb1ab5567dbfR19). To fix these test failures and to make the tests more resilient to potential future additive changes to the properties of the identity object, 57472128f4717bc816b5e21ea68d91ff0e92aad2 updates the tests to assert the value of the `login` property, not the value of the entire identity object.