### PR TITLE
Don't call `portalDelegate.setActiveEditorProxy` if editor didn't change

### DIFF
--- a/lib/portal.js
+++ b/lib/portal.js
@@ -273,9 +273,11 @@ class Portal {
       editorProxy = this.deserializeEditorProxy(editorProxyMessage)
     }
 
-    this.activeEditorProxy = editorProxy
-    this.delegate.setActiveEditorProxy(this.activeEditorProxy)
-    if (this.activeEditorProxy) this.activeEditorProxy.follow(1)
+    if (editorProxy != this.activeEditorProxy) {
+      this.activeEditorProxy = editorProxy
+      this.delegate.setActiveEditorProxy(this.activeEditorProxy)
+      if (this.activeEditorProxy) this.activeEditorProxy.follow(1)
+    }
   }
 
   receiveSiteAssignment (siteAssignment) {

--- a/test/portal.test.js
+++ b/test/portal.test.js
@@ -161,12 +161,15 @@ suite('Portal', () => {
     }
 
     {
+      assert.equal(guestPortal.testDelegate.getActiveBufferProxyURI(), 'original-uri')
       guestPortal.testDelegate.activeEditorProxyChangeCount = 0
+
       // Ignore editor proxy switch for an already disposed buffer proxy.
       const newBufferProxy = await hostPortal.createBufferProxy({uri: 'new-uri', text: ''})
       const newEditorProxy = await hostPortal.createEditorProxy({bufferProxy: newBufferProxy})
       hostPortal.setActiveEditorProxy(newEditorProxy)
       newBufferProxy.dispose()
+      hostPortal.setActiveEditorProxy(originalEditorProxy)
       hostPortal.setActiveEditorProxy(null)
       await condition(() => (
         guestPortal.testDelegate.getActiveBufferProxyURI() === null &&
@@ -175,12 +178,15 @@ suite('Portal', () => {
     }
 
     {
+      assert.equal(guestPortal.testDelegate.getActiveBufferProxyURI(), null)
       guestPortal.testDelegate.activeEditorProxyChangeCount = 0
+
       // Ignore editor proxy switch for an already disposed editor proxy.
       const newBufferProxy = await hostPortal.createBufferProxy({uri: 'new-uri', text: ''})
       const newEditorProxy = await hostPortal.createEditorProxy({bufferProxy: newBufferProxy})
       hostPortal.setActiveEditorProxy(newEditorProxy)
       newEditorProxy.dispose()
+      hostPortal.setActiveEditorProxy(null)
       hostPortal.setActiveEditorProxy(originalEditorProxy)
       await condition(() => (
         guestPortal.testDelegate.getActiveBufferProxyURI() === 'original-uri' &&

--- a/test/portal.test.js
+++ b/test/portal.test.js
@@ -123,76 +123,94 @@ suite('Portal', () => {
     assert.deepEqual(guest2Portal.getSiteIdentity(3), guest2Identity)
   })
 
-  test('changing active editor proxy', async () => {
-    const hostPeerPool = await buildPeerPool('host', server)
-    const guestPeerPool = await buildPeerPool('guest', server)
-
-    const hostPortal = await buildPortal('portal', hostPeerPool)
-    const guestPortal = await buildPortal('portal', guestPeerPool, 'host')
-    await guestPortal.join()
-    assert(guestPortal.testDelegate.getActiveEditorProxy() === null)
-    guestPortal.testDelegate.activeEditorProxyChangeCount = 0
-
-    // Don't notify guests when setting the active editor proxy to the same value it currently has.
-    hostPortal.setActiveEditorProxy(hostPortal.testDelegate.getActiveEditorProxy())
-
-    // Set the active editor proxy to a different value to ensure guests are notified only of this change.
-    const originalBufferProxy = await hostPortal.createBufferProxy({uri: 'original-uri', text: ''})
-    const originalEditorProxy = await hostPortal.createEditorProxy({bufferProxy: originalBufferProxy})
-    hostPortal.setActiveEditorProxy(originalEditorProxy)
-    await condition(() => (
-      guestPortal.testDelegate.getActiveBufferProxyURI() === 'original-uri' &&
-      guestPortal.testDelegate.activeEditorProxyChangeCount === 1
-    ))
-
-    {
+  suite('changing active editor proxy', () => {
+    test('host only notifies guests when active editor proxy has changed', async () => {
+      const hostPeerPool = await buildPeerPool('host', server)
+      const guestPeerPool = await buildPeerPool('guest', server)
+      const hostPortal = await buildPortal('portal', hostPeerPool)
+      const guestPortal = await buildPortal('portal', guestPeerPool, 'host')
+      await guestPortal.join()
       guestPortal.testDelegate.activeEditorProxyChangeCount = 0
-      // Ensure no race condition occurs on the guest when fetching new editor
-      // proxies for the first time and, at the same time, receiving a request
-      // to switch to a previous editor proxy.
-      const newBufferProxy = await hostPortal.createBufferProxy({uri: 'new-uri', text: ''})
-      const newEditorProxy = await hostPortal.createEditorProxy({bufferProxy: newBufferProxy})
-      hostPortal.setActiveEditorProxy(newEditorProxy)
+
+      // Don't notify guests when setting the active editor proxy to the same value it currently has.
+      hostPortal.setActiveEditorProxy(hostPortal.testDelegate.getActiveEditorProxy())
+
+      // Set the active editor proxy to a different value to ensure guests are notified only of this change.
+      const originalBufferProxy = await hostPortal.createBufferProxy({uri: 'original-uri', text: ''})
+      const originalEditorProxy = await hostPortal.createEditorProxy({bufferProxy: originalBufferProxy})
       hostPortal.setActiveEditorProxy(originalEditorProxy)
       await condition(() => (
         guestPortal.testDelegate.getActiveBufferProxyURI() === 'original-uri' &&
-        guestPortal.testDelegate.activeEditorProxyChangeCount === 2
+        guestPortal.testDelegate.activeEditorProxyChangeCount === 1
       ))
-    }
+    })
 
-    {
-      assert.equal(guestPortal.testDelegate.getActiveBufferProxyURI(), 'original-uri')
+    test('guest gracefully handles race conditions', async () => {
+      const hostPeerPool = await buildPeerPool('host', server)
+      const guestPeerPool = await buildPeerPool('guest', server)
+      const hostPortal = await buildPortal('portal', hostPeerPool)
+      const guestPortal = await buildPortal('portal', guestPeerPool, 'host')
+      await guestPortal.join()
       guestPortal.testDelegate.activeEditorProxyChangeCount = 0
 
-      // Ignore editor proxy switch for an already disposed buffer proxy.
+      // Ensure no race condition occurs on the guest when fetching new editor
+      // proxies for the first time and, at the same time, receiving a request
+      // to switch to a previous value of active editor proxy.
       const newBufferProxy = await hostPortal.createBufferProxy({uri: 'new-uri', text: ''})
       const newEditorProxy = await hostPortal.createEditorProxy({bufferProxy: newBufferProxy})
       hostPortal.setActiveEditorProxy(newEditorProxy)
-      newBufferProxy.dispose()
-      hostPortal.setActiveEditorProxy(originalEditorProxy)
       hostPortal.setActiveEditorProxy(null)
       await condition(() => (
         guestPortal.testDelegate.getActiveBufferProxyURI() === null &&
-        guestPortal.testDelegate.activeEditorProxyChangeCount === 1
+        guestPortal.testDelegate.activeEditorProxyChangeCount === 2
       ))
-    }
+    })
 
-    {
-      assert.equal(guestPortal.testDelegate.getActiveBufferProxyURI(), null)
+    test('guest gracefully handles switching to an editor proxy whose buffer has already been destroyed', async () => {
+      const hostPeerPool = await buildPeerPool('host', server)
+      const guestPeerPool = await buildPeerPool('guest', server)
+      const hostPortal = await buildPortal('portal', hostPeerPool)
+      const guestPortal = await buildPortal('portal', guestPeerPool, 'host')
+      await guestPortal.join()
       guestPortal.testDelegate.activeEditorProxyChangeCount = 0
 
-      // Ignore editor proxy switch for an already disposed editor proxy.
-      const newBufferProxy = await hostPortal.createBufferProxy({uri: 'new-uri', text: ''})
-      const newEditorProxy = await hostPortal.createEditorProxy({bufferProxy: newBufferProxy})
-      hostPortal.setActiveEditorProxy(newEditorProxy)
-      newEditorProxy.dispose()
+      const bufferProxy1 = await hostPortal.createBufferProxy({uri: 'uri-1', text: ''})
+      const editorProxy1 = await hostPortal.createEditorProxy({bufferProxy: bufferProxy1})
+      const bufferProxy2 = await hostPortal.createBufferProxy({uri: 'uri-2', text: ''})
+      const editorProxy2 = await hostPortal.createEditorProxy({bufferProxy: bufferProxy2})
+
+      hostPortal.setActiveEditorProxy(editorProxy1)
+      bufferProxy1.dispose()
       hostPortal.setActiveEditorProxy(null)
-      hostPortal.setActiveEditorProxy(originalEditorProxy)
+      hostPortal.setActiveEditorProxy(editorProxy2)
       await condition(() => (
-        guestPortal.testDelegate.getActiveBufferProxyURI() === 'original-uri' &&
+        guestPortal.testDelegate.getActiveBufferProxyURI() === 'uri-2' &&
         guestPortal.testDelegate.activeEditorProxyChangeCount === 1
       ))
-    }
+    })
+
+    test('guest gracefully handles switching to an editor proxy that has already been destroyed', async () => {
+      const hostPeerPool = await buildPeerPool('host', server)
+      const guestPeerPool = await buildPeerPool('guest', server)
+      const hostPortal = await buildPortal('portal', hostPeerPool)
+      const guestPortal = await buildPortal('portal', guestPeerPool, 'host')
+      await guestPortal.join()
+      guestPortal.testDelegate.activeEditorProxyChangeCount = 0
+
+      const bufferProxy1 = await hostPortal.createBufferProxy({uri: 'uri-1', text: ''})
+      const editorProxy1 = await hostPortal.createEditorProxy({bufferProxy: bufferProxy1})
+      const bufferProxy2 = await hostPortal.createBufferProxy({uri: 'uri-2', text: ''})
+      const editorProxy2 = await hostPortal.createEditorProxy({bufferProxy: bufferProxy2})
+
+      hostPortal.setActiveEditorProxy(editorProxy1)
+      editorProxy1.dispose()
+      hostPortal.setActiveEditorProxy(null)
+      hostPortal.setActiveEditorProxy(editorProxy2)
+      await condition(() => (
+        guestPortal.testDelegate.getActiveBufferProxyURI() === 'uri-2' &&
+        guestPortal.testDelegate.activeEditorProxyChangeCount === 1
+      ))
+    })
   })
 
   async function buildPortal (portalId, peerPool, hostPeerId) {


### PR DESCRIPTION
This addresses a bug in the contract of `PortalDelegate.setActiveEditorProxy`. When rapidly creating a new editor proxy, switching to it, destroying it and then going back to the previously active editor proxy, we would end up calling `setActiveEditorProxy` on the delegate twice with the same value.

This violated the contract with the Teletype package (which provides an implementation of a portal delegate), which was throwing the following exception when the above scenario occurred:

```
Uncaught (in promise) TypeError: Cannot read property 'getItems' of undefined
  at GuestPortalBinding.replaceActivePaneItem (~/.atom/packages/teletype/lib/guest-portal-binding.js:159:25)
  at lastSetActiveEditorProxyPromise.lastSetActiveEditorProxyPromise.then (~/.atom/packages/teletype/lib/guest-portal-binding.js:98:20)
```

🍐'd with @jasonrudolph 