### PR TITLE
Browser support

### DIFF
--- a/lib/rest-gateway.js
+++ b/lib/rest-gateway.js
@@ -1,5 +1,3 @@
-const {URL} = require('url')
-
 module.exports =
 class RestGateway {
   constructor ({baseURL, oauthToken}) {
@@ -12,7 +10,7 @@ class RestGateway {
   }
 
   async get (relativeURL, options) {
-    const url = new URL(relativeURL, this.baseURL).toString()
+    const url = this.getAbsoluteURL(relativeURL)
     const response = await window.fetch(url, {method: 'GET', headers: this.getDefaultHeaders()})
     const {ok, status} = response
     const body = await response.json()
@@ -20,7 +18,7 @@ class RestGateway {
   }
 
   async post (relativeURL, requestBody) {
-    const url = new URL(relativeURL, this.baseURL).toString()
+    const url = this.getAbsoluteURL(relativeURL)
     const response = await window.fetch(url, {
       method: 'POST',
       headers: Object.assign(this.getDefaultHeaders(), {'Content-Type': 'application/json'}),
@@ -37,5 +35,9 @@ class RestGateway {
     if (this.oauthToken) headers['GitHub-OAuth-token'] = this.oauthToken
 
     return headers
+  }
+
+  getAbsoluteURL (relativeURL) {
+    return this.baseURL + relativeURL
   }
 }


### PR DESCRIPTION
require('url') does not work as expected in the browser.

Replaced with universal-url shim, which works in Node and browser. This was the only
change needed in teletype-client to get it working in the browser.

Fixes #43  

Note: Changes are also required to teletype-server, namely CORS support and functionality to prevent leaking Twilio secret - I'll follow up with PRs on that project.