### PR TITLE
Forget active editor proxies of sites that have left the portal

### DIFF
--- a/lib/portal.js
+++ b/lib/portal.js
@@ -306,6 +306,7 @@ class Portal {
       this.unfollow()
     }
     this.tethersByFollowerId.delete(siteId)
+    this.activeEditorProxiesBySiteId.delete(siteId)
     this.updateActivePositions()
   }
 

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -195,6 +195,29 @@ suite('Client Integration', () => {
       guest1PortalDelegate.getEditorProxies().length === 0 &&
       guest2PortalDelegate.getEditorProxies().length === 0
     ))
+
+    const hostBufferProxy3 = await hostPortal.createBufferProxy({uri: 'buffer-c', text: ''})
+    const hostEditorProxy3 = await hostPortal.createEditorProxy({bufferProxy: hostBufferProxy3})
+    hostPortal.activateEditorProxy(hostEditorProxy3)
+
+    const hostBufferProxy4 = await hostPortal.createBufferProxy({uri: 'buffer-d', text: ''})
+    const hostEditorProxy4 = await hostPortal.createEditorProxy({bufferProxy: hostBufferProxy4})
+    hostPortal.activateEditorProxy(hostEditorProxy4)
+
+    await condition(() => (
+      guest1PortalDelegate.getEditorProxies().length === 2 &&
+      guest2PortalDelegate.getEditorProxies().length === 2
+    ))
+
+    // Ensure active editor proxies of sites that have left the portal are forgotten.
+    guest2Portal.activateEditorProxy(guest2PortalDelegate.editorProxyForURI('buffer-c'))
+    guest2Portal.dispose()
+    const guest3 = await buildClient()
+    const guest3Portal = await guest3.joinPortal(hostPortal.id)
+    const guest3PortalDelegate = new FakePortalDelegate()
+    guest3Portal.setDelegate(guest3PortalDelegate)
+
+    assert.equal(guest3PortalDelegate.getEditorProxies().length, 1)
   })
 
   suite('tethering to other participants', () => {


### PR DESCRIPTION
Previously, we were mistakenly keeping active editor proxies of sites that had left the portal. Other than occupying unnecessary memory, this was also causing the host to transmit such proxies to new participants too.

With this pull request, every time a site leaves the portal, we will now update `activeEditorProxiesBySiteId` and delete the editor proxy that corresponds to the user who has just left.

/cc: @jasonrudolph @nathansobo 