### PR TITLE
Detect disconnects on Electron 1.7

### DIFF
--- a/lib/peer-connection.js
+++ b/lib/peer-connection.js
@@ -1,6 +1,8 @@
 require('webrtc-adapter')
 
-MAX_SEND_RETRY_COUNT = 5
+const MAX_SEND_RETRY_COUNT = 5
+const MULTIPART_MASK = 0b00000001
+const DISCONNECT_MASK = 0b00000010
 
 const convertToProtobufCompatibleBuffer = require('./convert-to-protobuf-compatible-buffer')
 const Errors = require('./errors')
@@ -84,7 +86,16 @@ class PeerConnection {
     // the a star network hub disconnects all its peers and needs to
     // inform the remaining peers of the disconnection as each peer leaves.
     process.nextTick(() => {
-      if (this.channel) this.channel.close()
+      if (this.channel) {
+        try {
+          this.channel.send(Buffer.alloc(1, DISCONNECT_MASK))
+        } catch (e) {
+          // Ignore the exception since the connection is about to be closed.
+        } finally {
+          this.channel.close()
+        }
+      }
+
       if (this.rtcPeerConnection.iceConnectionState !== 'closed') {
         this.rtcPeerConnection.close()
       }
@@ -242,12 +253,15 @@ class PeerConnection {
         this.incomingMultipartEnvelopeOffset = 0
       }
     } else {
-      const multiPartByte = data.readUInt8(0)
-      if (multiPartByte & 1) {
+      const metadataByte = data.readUInt8(0)
+
+      if (metadataByte & MULTIPART_MASK) {
         const envelopeSize = data.readUInt32BE(1)
         this.incomingMultipartEnvelope = Buffer.alloc(envelopeSize)
         data.copy(this.incomingMultipartEnvelope, 0)
         this.incomingMultipartEnvelopeOffset = data.length
+      } else if (metadataByte & DISCONNECT_MASK) {
+        this.disconnect()
       } else {
         this.finishReceiving(data)
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -579,9 +579,9 @@
       "dev": true
     },
     "electron": {
-      "version": "1.6.11",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-1.6.11.tgz",
-      "integrity": "sha1-vnnA69zv7bW/KBF0CYAPpTus7/o=",
+      "version": "1.7.10",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-1.7.10.tgz",
+      "integrity": "sha1-Oj6D2WX9f6/kc76N349HJWG2JT0=",
       "dev": true,
       "requires": {
         "@types/node": "7.0.43",
@@ -2472,6 +2472,14 @@
       "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
       "dev": true
     },
+    "rtcpeerconnection-shim": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/rtcpeerconnection-shim/-/rtcpeerconnection-shim-1.2.5.tgz",
+      "integrity": "sha512-2oLVHZZMk/TsU9JqgrQYwdkOsDOeIalM3STqWjI1LtXrSrInHdig6CysSoTmEublMxnuy/F2i5NXE6tiIh9tZQ==",
+      "requires": {
+        "sdp": "2.4.0"
+      }
+    },
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
@@ -2969,10 +2977,11 @@
       }
     },
     "webrtc-adapter": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-4.2.2.tgz",
-      "integrity": "sha1-F4lsBHCE/UxWeVigzUMh4X8ydzw=",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-6.0.4.tgz",
+      "integrity": "sha512-T0WBRAsIi9gxgcwZgUCCZQHmMZI+P7CSl7YEdy1ILECQikd0zYmmtURd5MUCY0T0GEQ+5HVb/QrkH1SE1/MAbQ==",
       "requires": {
+        "rtcpeerconnection-shim": "1.2.5",
         "sdp": "2.4.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -15,13 +15,13 @@
     "google-protobuf": "^3.4.0",
     "pusher-js": "^4.1.0",
     "uuid": "^3.1.0",
-    "webrtc-adapter": "^4.2.1"
+    "webrtc-adapter": "^6.0.4"
   },
   "devDependencies": {
     "@atom/teletype-server": "^0.18.0",
     "deep-equal": "^1.0.1",
     "dotenv": "^4.0.0",
-    "electron": "1.6.11",
+    "electron": "1.7.10",
     "electron-mocha": "^4.0.0"
   }
 }


### PR DESCRIPTION
**The commits in this PR were written by @as-cii, but I'm opening it to keep things moving.**

On Electron <= 1.6 we used to receive an `iceconnectionstatechange` event whenever the other end of the connection hung up. On Electron 1.7 and newer this event is not being fired anymore, leaving one side of the connection potentially open forever.

With this commit a disconnection message will be explicitly sent every time one of the two sides of the connection decides to terminate the communication. The other party can then interpret this message and, in turn, close its side of the connection.

* [x] Get tests passing on Electron 1.7
* [x] Test with `teletype` package running in Atom 1.25 (Electron 1.7)
* [x] Test with `teletype` package running  in Atom 1.24 (Electron 1.6)