### PR TITLE
Bump protocol version from 5 to 6

### DIFF
--- a/lib/teletype-client.js
+++ b/lib/teletype-client.js
@@ -9,7 +9,7 @@ const RestGateway = require('./rest-gateway')
 const {Emitter} = require('event-kit')
 const NOOP = () => {}
 const DEFAULT_TETHER_DISCONNECT_WINDOW = 1000
-const LOCAL_PROTOCOL_VERSION = 5
+const LOCAL_PROTOCOL_VERSION = 6
 
 module.exports =
 class TeletypeClient {


### PR DESCRIPTION
Back in #48 we enhanced the first byte sent with every message in `PeerConnection` to allow specifying if the message was a disconnection message, a multipart message or a simple message.

Doing so, however, changed the protocol in a non-backward compatible manner, as older clients are unable to interpret disconnection messages. Hence, with this pull request we are bumping the protocol version so that everybody is forced to upgrade to the latest teletype version.

We are going to wait to test the effects of #48 a little more thoroughly before merging this pull request, so please don't merge it yet (even if tests are green).

TODO:

* [x] Test that #48 works as expected
* [x] Merge this pull request
* [ ] Bump the @atom/teletype-client module version on NPM
* [ ] Use it on teletype
* [ ] Bump the protocol on @atom/teletype-server and deploy a new version (first to staging, then to production)
* [ ] Publish a new version of the teletype package on APM

/cc: @nathansobo @jasonrudolph 