### PR TITLE
Improve diagnostics for HTTP request errors

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -4,6 +4,11 @@ class ClientOutOfDateError extends Error {
   }
 }
 
+class HTTPRequestError extends Error {
+  constructor () {
+    super(...arguments)
+  }
+}
 class NetworkConnectionError extends Error {
   constructor () {
     super(...arguments)
@@ -54,6 +59,7 @@ class PubSubConnectionError extends Error {
 
 module.exports = {
   ClientOutOfDateError,
+  HTTPRequestError,
   NetworkConnectionError,
   InvalidAuthenticationTokenError,
   UnexpectedAuthenticationError,

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -9,6 +9,7 @@ class HTTPRequestError extends Error {
     super(...arguments)
   }
 }
+
 class NetworkConnectionError extends Error {
   constructor () {
     super(...arguments)

--- a/lib/rest-gateway.js
+++ b/lib/rest-gateway.js
@@ -12,13 +12,14 @@ class RestGateway {
   }
 
   async get (relativeURL, options) {
+    const method = 'GET'
     const url = this.getAbsoluteURL(relativeURL)
     let response
     try {
-      response = await window.fetch(url, {method: 'GET', headers: this.getDefaultHeaders()})
+      response = await window.fetch(url, {method, headers: this.getDefaultHeaders()})
     } catch (e) {
       const error = new HTTPRequestError('Connection failure')
-      error.diagnosticMessage = getDiagnosticMessage({verb: 'GET', url})
+      error.diagnosticMessage = getDiagnosticMessage({method, url})
       throw error
     }
 
@@ -30,7 +31,7 @@ class RestGateway {
       return {ok, body, status}
     } catch (e) {
       const error = new HTTPRequestError('Unexpected response')
-      error.diagnosticMessage = getDiagnosticMessage({verb: 'GET', url, status, rawBody})
+      error.diagnosticMessage = getDiagnosticMessage({method, url, status, rawBody})
       throw error
     }
   }
@@ -62,8 +63,8 @@ class RestGateway {
 
 const PORTAL_ID_REGEXP = /[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}/g
 
-function getDiagnosticMessage ({verb, url, status, rawBody}) {
-  let message = `Request: ${verb} ${url}`
+function getDiagnosticMessage ({method, url, status, rawBody}) {
+  let message = `Request: ${method} ${url}`
   if (status) message += `\nStatus Code: ${status}`
   if (rawBody) message += `\nBody: ${rawBody}`
   return message.replace(PORTAL_ID_REGEXP, 'REDACTED')

--- a/lib/rest-gateway.js
+++ b/lib/rest-gateway.js
@@ -13,7 +13,15 @@ class RestGateway {
 
   async get (relativeURL, options) {
     const url = this.getAbsoluteURL(relativeURL)
-    const response = await window.fetch(url, {method: 'GET', headers: this.getDefaultHeaders()})
+    let response
+    try {
+      response = await window.fetch(url, {method: 'GET', headers: this.getDefaultHeaders()})
+    } catch (e) {
+      const error = new HTTPRequestError('Connection failure')
+      error.diagnosticMessage = getDiagnosticMessage({verb: 'GET', url})
+      throw error
+    }
+
     const {ok, status} = response
     const rawBody = await response.text()
 
@@ -55,10 +63,8 @@ class RestGateway {
 const PORTAL_ID_REGEXP = /[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}/g
 
 function getDiagnosticMessage ({verb, url, status, rawBody}) {
-  const diagnosticMessage =
-    `URL: GET ${url}\n` +
-    `Status Code: ${status}\n` +
-    `Body: ${rawBody}`
-
-  return diagnosticMessage.replace(PORTAL_ID_REGEXP, 'REDACTED')
+  let message = `Request: ${verb} ${url}`
+  if (status) message += `\nStatus Code: ${status}`
+  if (rawBody) message += `\nBody: ${rawBody}`
+  return message.replace(PORTAL_ID_REGEXP, 'REDACTED')
 }

--- a/lib/rest-gateway.js
+++ b/lib/rest-gateway.js
@@ -37,16 +37,32 @@ class RestGateway {
   }
 
   async post (relativeURL, requestBody) {
+    const method = 'POST'
     const url = this.getAbsoluteURL(relativeURL)
-    const response = await window.fetch(url, {
-      method: 'POST',
-      headers: Object.assign(this.getDefaultHeaders(), {'Content-Type': 'application/json'}),
-      body: JSON.stringify(requestBody)
-    })
+    let response
+    try {
+      response = await window.fetch(url, {
+        method,
+        headers: Object.assign(this.getDefaultHeaders(), {'Content-Type': 'application/json'}),
+        body: JSON.stringify(requestBody)
+      })
+    } catch (e) {
+      const error = new HTTPRequestError('Connection failure')
+      error.diagnosticMessage = getDiagnosticMessage({method, url})
+      throw error
+    }
 
     const {ok, status} = response
-    const body = await response.json()
-    return {ok, body, status}
+    const rawBody = await response.text()
+
+    try {
+      const body = JSON.parse(rawBody)
+      return {ok, body, status}
+    } catch (e) {
+      const error = new HTTPRequestError('Unexpected response')
+      error.diagnosticMessage = getDiagnosticMessage({method, url, status, rawBody})
+      throw error
+    }
   }
 
   getDefaultHeaders () {

--- a/lib/rest-gateway.js
+++ b/lib/rest-gateway.js
@@ -1,3 +1,5 @@
+const {HTTPRequestError} = require('./errors')
+
 module.exports =
 class RestGateway {
   constructor ({baseURL, oauthToken}) {
@@ -13,8 +15,16 @@ class RestGateway {
     const url = this.getAbsoluteURL(relativeURL)
     const response = await window.fetch(url, {method: 'GET', headers: this.getDefaultHeaders()})
     const {ok, status} = response
-    const body = await response.json()
-    return {ok, body, status}
+    const rawBody = await response.text()
+
+    try {
+      const body = JSON.parse(rawBody)
+      return {ok, body, status}
+    } catch (e) {
+      const error = new HTTPRequestError('Unexpected response')
+      error.diagnosticMessage = getDiagnosticMessage({verb: 'GET', url, status, rawBody})
+      throw error
+    }
   }
 
   async post (relativeURL, requestBody) {
@@ -40,4 +50,15 @@ class RestGateway {
   getAbsoluteURL (relativeURL) {
     return this.baseURL + relativeURL
   }
+}
+
+const PORTAL_ID_REGEXP = /[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}/g
+
+function getDiagnosticMessage ({verb, url, status, rawBody}) {
+  const diagnosticMessage =
+    `URL: GET ${url}\n` +
+    `Status Code: ${status}\n` +
+    `Body: ${rawBody}`
+
+  return diagnosticMessage.replace(PORTAL_ID_REGEXP, 'REDACTED')
 }

--- a/lib/rest-gateway.js
+++ b/lib/rest-gateway.js
@@ -11,41 +11,26 @@ class RestGateway {
     this.oauthToken = oauthToken
   }
 
-  async get (relativeURL, options) {
-    const method = 'GET'
-    const url = this.getAbsoluteURL(relativeURL)
-    let response
-    try {
-      response = await window.fetch(url, {method, headers: this.getDefaultHeaders()})
-    } catch (e) {
-      const error = new HTTPRequestError('Connection failure')
-      error.diagnosticMessage = getDiagnosticMessage({method, url})
-      throw error
-    }
-
-    const {ok, status} = response
-    const rawBody = await response.text()
-
-    try {
-      const body = JSON.parse(rawBody)
-      return {ok, body, status}
-    } catch (e) {
-      const error = new HTTPRequestError('Unexpected response')
-      error.diagnosticMessage = getDiagnosticMessage({method, url, status, rawBody})
-      throw error
-    }
+  get (relativeURL, options) {
+    return this.fetch(relativeURL, {
+      method: 'GET',
+      headers: this.getDefaultHeaders()
+    })
   }
 
-  async post (relativeURL, requestBody) {
-    const method = 'POST'
+  post (relativeURL, requestBody) {
+    return this.fetch(relativeURL, {
+      method: 'POST',
+      headers: Object.assign(this.getDefaultHeaders(), {'Content-Type': 'application/json'}),
+      body: JSON.stringify(requestBody)
+    })
+  }
+
+  async fetch (relativeURL, {method, headers, body}) {
     const url = this.getAbsoluteURL(relativeURL)
     let response
     try {
-      response = await window.fetch(url, {
-        method,
-        headers: Object.assign(this.getDefaultHeaders(), {'Content-Type': 'application/json'}),
-        body: JSON.stringify(requestBody)
-      })
+      response = await window.fetch(url, {method, headers, body})
     } catch (e) {
       const error = new HTTPRequestError('Connection failure')
       error.diagnosticMessage = getDiagnosticMessage({method, url})

--- a/test/rest-gateway.test.js
+++ b/test/rest-gateway.test.js
@@ -15,7 +15,7 @@ suite('RestGateway', () => {
   })
 
   suite('get', () => {
-    test('successful response', async () => {
+    test('successful request and response', async () => {
       const address = listen(function (request, response) {
          response.writeHead(200, {'Content-Type': 'application/json'})
          response.write('{"a": 1}')
@@ -26,6 +26,18 @@ suite('RestGateway', () => {
       const response = await gateway.get('/')
       assert(response.ok)
       assert.deepEqual(response.body, {a: 1})
+    })
+
+    test('failed request', async () => {
+      const gateway = new RestGateway({baseURL: 'http://localhost:0987654321'})
+      let error
+      try {
+        await gateway.get('/foo/b9e13e6b-9e6e-492c-b4d9-4ec75fd9c2bc/bar')
+      } catch (e) {
+        error = e
+      }
+      assert(error instanceof Errors.HTTPRequestError)
+      assert(error.diagnosticMessage.includes('/foo/REDACTED/bar'))
     })
 
     test('non-JSON response', async () => {

--- a/test/rest-gateway.test.js
+++ b/test/rest-gateway.test.js
@@ -1,0 +1,57 @@
+require('./setup')
+const assert = require('assert')
+const http = require('http')
+const Errors = require('../lib/errors')
+const RestGateway = require('../lib/rest-gateway')
+
+suite('RestGateway', () => {
+  const servers = []
+
+  teardown(() => {
+    for (const server of servers) {
+      server.close()
+    }
+    servers.length = 0
+  })
+
+  suite('get', () => {
+    test('successful response', async () => {
+      const address = listen(function (request, response) {
+         response.writeHead(200, {'Content-Type': 'application/json'})
+         response.write('{"a": 1}')
+         response.end()
+      })
+
+      const gateway = new RestGateway({baseURL: address})
+      const response = await gateway.get('/')
+      assert(response.ok)
+      assert.deepEqual(response.body, {a: 1})
+    })
+
+    test('non-JSON response', async () => {
+      const address = listen(function (request, response) {
+        response.writeHead(200, {'Content-Type': 'text/plain'})
+        response.write('some unexpected response (b9e13e6b-9e6e-492c-b4d9-4ec75fd9c2bc)')
+        response.end()
+      })
+
+      const gateway = new RestGateway({baseURL: address})
+      let error
+      try {
+        await gateway.get('/foo/b9e13e6b-9e6e-492c-b4d9-4ec75fd9c2bc/bar')
+      } catch (e) {
+        error = e
+      }
+      assert(error instanceof Errors.HTTPRequestError)
+      assert(error.diagnosticMessage.includes('200'))
+      assert(error.diagnosticMessage.includes('some unexpected response (REDACTED)'))
+      assert(error.diagnosticMessage.includes('/foo/REDACTED/bar'))
+    })
+  })
+
+  function listen (requestListener) {
+    const server = http.createServer(requestListener).listen(0)
+    servers.push(server)
+    return `http://localhost:${server.address().port}`
+  }
+})


### PR DESCRIPTION
To aid in diagnosing and debugging errors that happen when processing HTTP requests and responses, this pull request enhances `RestGateway` to throw an `HTTPRequestError` with useful diagnostic info. In the teletype Atom package, we'll be able to use this info to help users report the root cause of package initialization errors (https://github.com/atom/teletype/issues/266).

🍐'd with @as-cii 

