### PR TITLE
⬆️ electron@1.7.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,9 +46,9 @@
       }
     },
     "@types/node": {
-      "version": "7.0.43",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.43.tgz",
-      "integrity": "sha512-7scYwwfHNppXvH/9JzakbVxk0o0QUILVk1Lv64GRaxwPuGpnF1QBiwdvhDpLcymb8BpomQL3KYoWKq3wUdDMhQ==",
+      "version": "7.0.52",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.52.tgz",
+      "integrity": "sha512-jjpyQsKGsOF/wUElNjfPULk+d8PKvJOIXk3IUeBYYmNCy5dMWfrI+JiixYNw8ppKOlcRwWTXFl0B+i5oGrf95Q==",
       "dev": true
     },
     "accepts": {
@@ -579,14 +579,14 @@
       "dev": true
     },
     "electron": {
-      "version": "1.7.10",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-1.7.10.tgz",
-      "integrity": "sha1-Oj6D2WX9f6/kc76N349HJWG2JT0=",
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-1.7.11.tgz",
+      "integrity": "sha1-mTtqp54OeafPzDafTIE/vZoLCNk=",
       "dev": true,
       "requires": {
-        "@types/node": "7.0.43",
+        "@types/node": "7.0.52",
         "electron-download": "3.3.0",
-        "extract-zip": "1.6.5"
+        "extract-zip": "1.6.6"
       }
     },
     "electron-download": {
@@ -601,7 +601,7 @@
         "minimist": "1.2.0",
         "nugget": "2.0.1",
         "path-exists": "2.1.0",
-        "rc": "1.2.1",
+        "rc": "1.2.5",
         "semver": "5.4.1",
         "sumchecker": "1.3.1"
       },
@@ -683,9 +683,9 @@
       }
     },
     "es6-promise": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.1.tgz",
-      "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
+      "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ==",
       "dev": true
     },
     "escape-html": {
@@ -794,24 +794,24 @@
       "dev": true
     },
     "extract-zip": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.5.tgz",
-      "integrity": "sha1-maBnNbbqIOqbcF13ms/8yHz/BEA=",
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.6.tgz",
+      "integrity": "sha1-EpDt6NINCHK0Kf0/NRyhKOxe+Fw=",
       "dev": true,
       "requires": {
         "concat-stream": "1.6.0",
-        "debug": "2.2.0",
+        "debug": "2.6.9",
         "mkdirp": "0.5.0",
         "yauzl": "2.4.1"
       },
       "dependencies": {
         "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
-            "ms": "0.7.1"
+            "ms": "2.0.0"
           }
         },
         "mkdirp": {
@@ -822,12 +822,6 @@
           "requires": {
             "minimist": "0.0.8"
           }
-        },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-          "dev": true
         }
       }
     },
@@ -1176,9 +1170,9 @@
       "dev": true
     },
     "ini": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-      "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
       "dev": true
     },
     "invert-kv": {
@@ -2264,13 +2258,13 @@
       }
     },
     "rc": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
-      "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.5.tgz",
+      "integrity": "sha1-J1zWh/bjs2zHVrqibf7oCnkDAf0=",
       "dev": true,
       "requires": {
         "deep-extend": "0.4.2",
-        "ini": "1.3.4",
+        "ini": "1.3.5",
         "minimist": "1.2.0",
         "strip-json-comments": "2.0.1"
       },
@@ -2789,7 +2783,7 @@
       "dev": true,
       "requires": {
         "debug": "2.6.8",
-        "es6-promise": "4.1.1"
+        "es6-promise": "4.2.4"
       }
     },
     "supports-color": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@atom/teletype-server": "^0.18.0",
     "deep-equal": "^1.0.1",
     "dotenv": "^4.0.0",
-    "electron": "1.7.10",
+    "electron": "1.7.11",
     "electron-mocha": "^4.0.0"
   }
 }


### PR DESCRIPTION
Electron 1.7.11 addresses [CVE-2018-1000006](https://electronjs.org/blog/protocol-handler-fix). That vulnerability doesn't impact teletype-client, but let's stay up to date nonetheless. 

🍐'd with @as-cii