### PR TITLE
Identify sites with no active editor proxy when relaying position info

### DIFF
--- a/lib/portal.js
+++ b/lib/portal.js
@@ -639,6 +639,8 @@ class Portal {
         }
 
         activePositions[siteId] = {editorProxy, position}
+      } else {
+        activePositions[siteId] = {editorProxy: null, position: null}
       }
     }
 

--- a/test/helpers/fake-portal-delegate.js
+++ b/test/helpers/fake-portal-delegate.js
@@ -69,7 +69,8 @@ class FakePortalDelegate {
   getActivePositions () {
     return Object.keys(this.activePositionsBySiteId).map((siteId) => {
       const {editorProxy, position} = this.activePositionsBySiteId[siteId]
-      return {siteId, editorProxyId: editorProxy.id, position}
+      const editorProxyId = editorProxy ? editorProxy.id : null
+      return {siteId, editorProxyId, position}
     })
   }
 

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -849,6 +849,14 @@ suite('Client Integration', () => {
       {siteId: 2, editorProxyId: hostEditorProxy2.id, position: point(1, 0)}
     ])
 
+    // Update active positions after participant switches focus to something outside of the portal.
+    hostPortal.activateEditorProxy(null)
+
+    await assertActivePositions([
+      {siteId: 1, editorProxyId: null, position: null},
+      {siteId: 2, editorProxyId: hostEditorProxy2.id, position: point(1, 0)}
+    ])
+
     function assertActivePositions (expectedPositions) {
       const alivePortals = portals.filter((p) => !p.disposed)
       return condition(() =>


### PR DESCRIPTION
In support of atom/teletype/pull/332, this pull request enhances `Portal::updateActivePositions` to notify delegates of active site positions for **all** sites, regardless of whether the site is currently viewing one of the portal's editors.

Prior to this change, if a site had no active editor proxy (e.g., the site has given focus to an item outside of the portal, like the "Settings" tab in Atom), the site would be excluded from the object passed to the delegate. With the changes in this pull request, the site is now included in the object passed to the delegate, and its position info has a `null` `editorProxy` property and a `null` `position` property.
