### PR TITLE
[Code Submission] RFC-002: Sync Buffer Path Changes from Host To Guest

### DIFF
--- a/lib/buffer-proxy.js
+++ b/lib/buffer-proxy.js
@@ -36,6 +36,7 @@ class BufferProxy {
       )
     } else {
       this.subscriptions.add(
+        this.router.onNotification(`/buffers/${id}/pathChange`, this.receivePathChanged.bind(this)),
         this.router.onNotification(`/buffers/${id}/disposal`, this.dispose.bind(this))
       )
     }
@@ -46,6 +47,7 @@ class BufferProxy {
   dispose () {
     this.subscriptions.dispose()
     if (this.delegate) this.delegate.dispose()
+    if (this.bufferFile) this.bufferFile.dispose()
     if (this.isHost) this.router.notify({channelId: `/buffers/${this.id}/disposal`})
     this.emitDidDispose()
   }
@@ -62,6 +64,7 @@ class BufferProxy {
     this.delegate = delegate
     if (this.siteId !== 1 && this.delegate) {
       this.delegate.setText(this.document.getText())
+      this.bufferFile = this.delegate.addFile(this)
     }
   }
 
@@ -162,6 +165,19 @@ class BufferProxy {
   requestSave () {
     assert(!this.isHost, 'Only guests can request a save')
     this.router.notify({recipientId: this.hostPeerId, channelId: `/buffers/${this.id}/save`})
+  }
+
+  requestPathChanged(newUri){
+    this.router.notify({channelId: `/buffers/${this.id}/pathChange`, body: newUri })
+    this.uri = newUri
+  }
+
+  receivePathChanged({body}){
+    var newUri = body
+    this.uri = newUri
+    if(this.bufferFile){
+      this.bufferFile.pathChanged()
+    }
   }
 
   receiveFetch ({requestId}) {


### PR DESCRIPTION
### Description of the Change

This is the changes to the **Teletype-Package** package mentioned in [RFC-002 Tracking](atom/teletype/352).

Please see [RFC-002](https://github.com/atom/teletype/issues/352) for details about the change.

### Verification Process
We tested our changes locally, and ensured that the `npm test` tests passed.

We were unsure of where additional tests for `buffer-proxy` should be placed, given the current structure of the test folder.

### Applicable Issues
Original Issue: [#147](atom/teletype/147)
