### PR TITLE
Bump protocol version from 7 to 8

### DIFF
--- a/lib/teletype-client.js
+++ b/lib/teletype-client.js
@@ -9,7 +9,7 @@ const RestGateway = require('./rest-gateway')
 const {Emitter} = require('event-kit')
 const NOOP = () => {}
 const DEFAULT_TETHER_DISCONNECT_WINDOW = 1000
-const LOCAL_PROTOCOL_VERSION = 7
+const LOCAL_PROTOCOL_VERSION = 8
 
 module.exports =
 class TeletypeClient {


### PR DESCRIPTION
In the next release of the Teletype package, Teletype will provide hosts with a portal URL, instead of just a portal ID. Guests can then follow that URL to quickly join the portal. [1]

If the host has upgraded to the new version of the package and the guest still has the old version, nothing will happen when the guest follows the portal URL (since the old version doesn't have support for handling URIs). To avoid this potential cause for confusion, this pull request bumps the protocol version so that everybody is prompted to upgrade to the latest teletype version.

TODO:

- [ ] Merge this pull request
- [ ] Bump the @atom/teletype-client module version on NPM
- [ ] Use the new version of teletype-client in teletype
- [ ] Bump the protocol on @atom/teletype-server and deploy a new version (first to staging, then to production)
- [ ] Publish a new version of the teletype package on APM

cc: @as-cii
refs: #49 (for prior art)

---

[1] In other words, guests no longer need to select the portal ID, copy it, switch to Atom, click the Teletype icon, click "Join a portal", paste in the portal ID, and then click "Join". Instead, just click the portal URL and you're done. :sweat_smile:
