### PR TITLE
Ignore the "leave notification" if we don't have info for the given member

### DIFF
--- a/lib/peer-connection.js
+++ b/lib/peer-connection.js
@@ -82,7 +82,7 @@ class PeerConnection {
     this.didDisconnect(this.remotePeerId)
     this.resolveDisconnectedPromise()
 
-    // Get channel a chance to flush. This helps avoid flaky tests where
+    // Give channel a chance to flush. This helps avoid flaky tests where
     // the a star network hub disconnects all its peers and needs to
     // inform the remaining peers of the disconnection as each peer leaves.
     process.nextTick(() => {

--- a/lib/star-overlay-network.js
+++ b/lib/star-overlay-network.js
@@ -249,6 +249,8 @@ class StarOverlayNetwork {
 
   receiveLeaveNotification (rawMessage, leaveNotification) {
     const memberId = leaveNotification.getMemberId()
+    if (!this.connectedMemberIds.has(memberId)) return
+
     if (this.isHub) {
       this.spokes.delete(memberId)
       this.forwardBroadcast(memberId, rawMessage)


### PR DESCRIPTION
This change is an attempt to prevent the issue reported in https://github.com/atom/teletype/issues/233#issuecomment-369276052.

We suspect that the root cause is some sort of race condition that occurs during the initial peer connection process in certain network conditions. We've attempted to write a test to reproduce the issue, but we've so far been unsuccessful in doing so. In reviewing the stack trace in https://github.com/atom/teletype/issues/233#issuecomment-369276052, we think there's a decent chance that this change will resolve the issue. For now, we'll ship this change and ask people to let us know if they continue to experience the bug.

:pear:'ed with @as-cii
