### PR TITLE
Don't send position updates for partially-joined guests

### DIFF
--- a/lib/portal.js
+++ b/lib/portal.js
@@ -92,7 +92,8 @@ class Portal {
 
   async join () {
     try {
-      await this.network.connectTo(this.hostPeerId)
+      this.networkConnectionPromise = this.network.connectTo(this.hostPeerId)
+      await this.networkConnectionPromise
     } catch (error) {
       this.dispose()
       throw error
@@ -309,7 +310,14 @@ class Portal {
   }
 
   getActiveSiteIds () {
-    return this.network.getMemberIds().map((id) => this.siteIdsByPeerId.get(id))
+    const connectedMemberIds = this.network.getMemberIds()
+    const activeSiteIds = []
+    for (let i = 0; i < connectedMemberIds.length; i++) {
+      const memberId = connectedMemberIds[i]
+      const siteId = this.siteIdsByPeerId.get(memberId)
+      if (siteId != null) activeSiteIds.push(siteId)
+    }
+    return activeSiteIds
   }
 
   getSiteIdentity (siteId) {
@@ -353,6 +361,7 @@ class Portal {
     this.assignNewSiteId(senderId)
     this.sendSubscriptionResponse(requestId)
     this.delegate.siteDidJoin(this.siteIdsByPeerId.get(senderId))
+    this.updateActivePositions()
   }
 
   assignNewSiteId (peerId) {


### PR DESCRIPTION
We expect this to resolve the issue described in https://github.com/atom/teletype/issues/360.
