### PR TITLE
Disconnect Mac Users that use Sleep

### DIFF
--- a/lib/peer-pool.js
+++ b/lib/peer-pool.js
@@ -118,7 +118,12 @@ class PeerPool {
   send (peerId, message) {
     const peerConnection = this.peerConnectionsById.get(peerId)
     if (peerConnection) {
-      peerConnection.send(message)
+      try {
+        peerConnection.send(message)
+      } catch (error) {
+        peerConnection.disconnect()
+      }
+
     } else {
       throw new Error('No connection to peer')
     }


### PR DESCRIPTION
### Description of the Change

When a Mac computer (as a Guest) goes to sleep, an `RTCDataChannel` error is thrown by PeerConnection, and is uncaught in PeerPool. Any time that the host or other guests attempt to move their cursor, or attempt to type anything, the host will receive this error again.

This PR will catch this error in PeerPool and make the offending Guest disconnect.

### Alternate Designs

N/A

### Benefits

This change will allow Guests to disconnect using `Sleep`, while having the host and remaining guests to continue to collaborate.


### Possible Drawbacks

If a fix to this bug is not implemented, then this is a major issue to guest <--> host connectivity for Mac users. Further, if there is a second guest (guest 2) when this error occurs, and this guest continues to type in the buffer, then the buffer will not be able to re-sync with the Host even after the 
guest who called `Sleep` (guest 1) has timed out.

### Verification Process
The changes made have been locally tested using a number of different scenarios using Macs and an Ubuntu machine.

Further, teletype and teletype-client test suites have been run.

### Applicable Issues

Origin Issue: atom/teletype#354