### PR TITLE
Include follow state when providing active position updates to delegate

### DIFF
--- a/lib/portal.js
+++ b/lib/portal.js
@@ -649,16 +649,17 @@ class Portal {
       const editorProxy = this.activeEditorProxyForSiteId(siteId)
       if (editorProxy) {
         let position
-        if (this.resolveFollowState(siteId) === FollowState.RETRACTED) {
+        const followState = this.resolveFollowState(siteId)
+        if (followState === FollowState.RETRACTED) {
           const leaderId = this.resolveLeaderSiteId(siteId)
           position = editorProxy.cursorPositionForSiteId(leaderId)
         } else {
           position = editorProxy.cursorPositionForSiteId(siteId)
         }
 
-        activePositions[siteId] = {editorProxy, position}
+        activePositions[siteId] = {editorProxy, position, followState}
       } else {
-        activePositions[siteId] = {editorProxy: null, position: null}
+        activePositions[siteId] = {editorProxy: null, position: null, followState: null}
       }
     }
 

--- a/test/helpers/fake-portal-delegate.js
+++ b/test/helpers/fake-portal-delegate.js
@@ -68,9 +68,9 @@ class FakePortalDelegate {
 
   getActivePositions () {
     return Object.keys(this.activePositionsBySiteId).map((siteId) => {
-      const {editorProxy, position} = this.activePositionsBySiteId[siteId]
+      const {editorProxy, position, followState} = this.activePositionsBySiteId[siteId]
       const editorProxyId = editorProxy ? editorProxy.id : null
-      return {siteId, editorProxyId, position}
+      return {siteId, editorProxyId, position, followState}
     })
   }
 

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -787,18 +787,17 @@ suite('Client Integration', () => {
     })
 
     await assertActivePositions([
-      {siteId: 1, editorProxyId: hostEditorProxy1.id, position: point(4, 4)},
-      {siteId: 2, editorProxyId: hostEditorProxy1.id, position: point(4, 4)},
-      {siteId: 3, editorProxyId: hostEditorProxy1.id, position: point(4, 4)}
+      {siteId: 1, editorProxyId: hostEditorProxy1.id, position: point(4, 4), followState: FollowState.DISCONNECTED},
+      {siteId: 2, editorProxyId: hostEditorProxy1.id, position: point(4, 4), followState: FollowState.RETRACTED},
+      {siteId: 3, editorProxyId: hostEditorProxy1.id, position: point(4, 4), followState: FollowState.RETRACTED}
     ])
-
     // Update active positions after a text change.
     hostBufferProxy1.setTextInRange(point(4, 0), point(4, 0), 'X')
 
     await assertActivePositions([
-      {siteId: 1, editorProxyId: hostEditorProxy1.id, position: point(4, 5)},
-      {siteId: 2, editorProxyId: hostEditorProxy1.id, position: point(4, 5)},
-      {siteId: 3, editorProxyId: hostEditorProxy1.id, position: point(4, 5)}
+      {siteId: 1, editorProxyId: hostEditorProxy1.id, position: point(4, 5), followState: FollowState.DISCONNECTED},
+      {siteId: 2, editorProxyId: hostEditorProxy1.id, position: point(4, 5), followState: FollowState.RETRACTED},
+      {siteId: 3, editorProxyId: hostEditorProxy1.id, position: point(4, 5), followState: FollowState.RETRACTED}
     ])
 
     // Update active positions after the leader changes.
@@ -808,9 +807,9 @@ suite('Client Integration', () => {
     guest2Portal.follow(guest1Portal.siteId)
 
     await assertActivePositions([
-      {siteId: 1, editorProxyId: hostEditorProxy1.id, position: point(4, 5)},
-      {siteId: 2, editorProxyId: hostEditorProxy1.id, position: point(5, 4)},
-      {siteId: 3, editorProxyId: hostEditorProxy1.id, position: point(5, 4)}
+      {siteId: 1, editorProxyId: hostEditorProxy1.id, position: point(4, 5), followState: FollowState.DISCONNECTED},
+      {siteId: 2, editorProxyId: hostEditorProxy1.id, position: point(5, 4), followState: FollowState.EXTENDED},
+      {siteId: 3, editorProxyId: hostEditorProxy1.id, position: point(5, 4), followState: FollowState.RETRACTED}
     ])
 
     // Update active positions after host switches to a different editor proxy.
@@ -822,9 +821,9 @@ suite('Client Integration', () => {
     hostPortal.activateEditorProxy(hostEditorProxy2)
 
     await assertActivePositions([
-      {siteId: 1, editorProxyId: hostEditorProxy2.id, position: point(2, 2)},
-      {siteId: 2, editorProxyId: hostEditorProxy1.id, position: point(5, 4)},
-      {siteId: 3, editorProxyId: hostEditorProxy1.id, position: point(5, 4)}
+      {siteId: 1, editorProxyId: hostEditorProxy2.id, position: point(2, 2), followState: FollowState.DISCONNECTED},
+      {siteId: 2, editorProxyId: hostEditorProxy1.id, position: point(5, 4), followState: FollowState.DISCONNECTED},
+      {siteId: 3, editorProxyId: hostEditorProxy1.id, position: point(5, 4), followState: FollowState.RETRACTED}
     ])
 
     // Update active positions after a guest switches to a different editor proxy.
@@ -836,25 +835,25 @@ suite('Client Integration', () => {
     }, {initialUpdate: true})
 
     await assertActivePositions([
-      {siteId: 1, editorProxyId: hostEditorProxy2.id, position: point(2, 2)},
-      {siteId: 2, editorProxyId: hostEditorProxy2.id, position: point(1, 0)},
-      {siteId: 3, editorProxyId: hostEditorProxy2.id, position: point(1, 0)}
+      {siteId: 1, editorProxyId: hostEditorProxy2.id, position: point(2, 2), followState: FollowState.DISCONNECTED},
+      {siteId: 2, editorProxyId: hostEditorProxy2.id, position: point(1, 0), followState: FollowState.DISCONNECTED},
+      {siteId: 3, editorProxyId: hostEditorProxy2.id, position: point(1, 0), followState: FollowState.RETRACTED}
     ])
 
     // Update active positions after a site disconnects.
     guest2Portal.dispose()
 
     await assertActivePositions([
-      {siteId: 1, editorProxyId: hostEditorProxy2.id, position: point(2, 2)},
-      {siteId: 2, editorProxyId: hostEditorProxy2.id, position: point(1, 0)}
+      {siteId: 1, editorProxyId: hostEditorProxy2.id, position: point(2, 2), followState: FollowState.DISCONNECTED},
+      {siteId: 2, editorProxyId: hostEditorProxy2.id, position: point(1, 0), followState: FollowState.DISCONNECTED}
     ])
 
     // Update active positions after participant switches focus to something outside of the portal.
     hostPortal.activateEditorProxy(null)
 
     await assertActivePositions([
-      {siteId: 1, editorProxyId: null, position: null},
-      {siteId: 2, editorProxyId: hostEditorProxy2.id, position: point(1, 0)}
+      {siteId: 1, editorProxyId: null, position: null, followState: null},
+      {siteId: 2, editorProxyId: hostEditorProxy2.id, position: point(1, 0), followState: FollowState.DISCONNECTED}
     ])
 
     function assertActivePositions (expectedPositions) {


### PR DESCRIPTION
In support of https://github.com/atom/teletype/issues/338, this pull request enhances the data provided when invoking `::updateActivePositions()` on the portal delegate. In addition to providing the editor proxy ID and the position for each site, we'll now provide the [follow state](https://github.com/atom/teletype-client/blob/f0cf0054d6ba3e923a31860ceefd0d78b94cdf99/lib/follow-state.js) as well.

Currently in atom/teletype, we update the `SitePositionsComponent` each time `::updateActivePositions()` is invoked on the portal delegate [1] [2]. By including the follow state in the data provided to the portal delegate, we can enhance atom/teletype to update the display of site position information each time the follow state changes. Specifically, when a site's follow state is _disconnected_ or _extended_, we can [show a colored border around the site's avatar to match the site's cursor color](https://github.com/atom/teletype/issues/338#issuecomment-371802426). And when the site's follow state becomes _retracted_, we can hide the border around the avatar, since the site's cursor isn't visible when they're retracted.

---

[1] https://github.com/atom/teletype/blob/7ac8380/lib/guest-portal-binding.js#L100

[2] https://github.com/atom/teletype/blob/7ac8380/lib/host-portal-binding.js#L87
