### PR TITLE
Disconnect PeerConnection on RTCDataChannel close event

### DIFF
--- a/lib/peer-connection.js
+++ b/lib/peer-connection.js
@@ -133,6 +133,7 @@ class PeerConnection {
     this.channel.binaryType = 'arraybuffer'
     this.channel.onerror = this.handleError.bind(this)
     this.channel.onmessage = ({data}) => this.receive(Buffer.from(data))
+    this.channel.onclose = () => this.disconnect()
 
     if (this.channel.readyState === 'open') {
       this.handleConnectionStateChange()


### PR DESCRIPTION
Fixes https://github.com/atom/teletype/issues/354

Supersedes https://github.com/atom/teletype-client/pull/60 as described in https://github.com/atom/teletype-client/pull/60#discussion_r183504938