### PR TITLE
Don't close RTCPeerConnection if it's already closed

### DIFF
--- a/lib/peer-connection.js
+++ b/lib/peer-connection.js
@@ -96,7 +96,7 @@ class PeerConnection {
         }
       }
 
-      if (this.rtcPeerConnection.connectionState !== 'closed') {
+      if (this.rtcPeerConnection.signalingState !== 'closed') {
         this.rtcPeerConnection.close()
       }
     })

--- a/lib/peer-connection.js
+++ b/lib/peer-connection.js
@@ -96,7 +96,7 @@ class PeerConnection {
         }
       }
 
-      if (this.rtcPeerConnection.iceConnectionState !== 'closed') {
+      if (this.rtcPeerConnection.connectionState !== 'closed') {
         this.rtcPeerConnection.close()
       }
     })


### PR DESCRIPTION
https://github.com/atom/teletype-client/pull/12 added logic to check the `iceConnectionState` [1] before attempting to close an `RTCPeerConnection` [2]. The issue reported in https://github.com/atom/teletype/issues/368 seems to indicate that the `RTCPeerConnection` may be closed even though the `iceConnectionState` [1] is not equal to `closed`. (Perhaps the `iceConnectionState` is equal to `failed` in these scenarios?)

The docs [3] indicate that the `signalingState` will be `closed` once the call to `RTCPeerConnection::close()` returns. With the change in this pull request, if the `signalingState` is already `closed`, we do *not* attempt to close the connection.

[1] https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/iceConnectionState
[2] https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection
[3] https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/close
