### PR TITLE
Lock webrtc-adapter dependency to version 6.1.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "google-protobuf": "^3.5.0",
     "pusher-js": "^4.2.2",
     "uuid": "^3.2.1",
-    "webrtc-adapter": "^6.1.5"
+    "webrtc-adapter": "~6.1"
   },
   "devDependencies": {
     "@atom/teletype-server": "^0.18.1",


### PR DESCRIPTION
Upgrading from webrtc-adapter 6.1.5 to 6.2.1 [breaks the build](https://travis-ci.org/atom/teletype-client/jobs/385265540#L1006) in a way that mimics the problem reported in https://github.com/atom/teletype/issues/382. In teletype-client, the `package-lock.json` file already uses webrtc-adapter 6.1.5 👌, but when apm installs the teletype package, webrtc-adapter `^6.1.5` gets resolved to webrtc-adapter `6.y`, for the highest value of y. As a result, this currently resolves to 6.2.1, which causes the problems referenced above. By depending on webrtc-adapter 6.1.x, we resolve the issue. 😅