### PR TITLE
support non-browser based environments

### DIFF
--- a/lib/isomorphic.js
+++ b/lib/isomorphic.js
@@ -1,7 +1,14 @@
 if (typeof window !== 'undefined') {
   const fetch = window.fetch;
+
+  // we force loading from the web version to take advantage of proxy settings.
+  // When under electron, the node version is normally loaded
+  const Pusher = require('pusher-js/dist/web/pusher')
+} else {
+    const Pusher = require('pusher-js')
 }
 
 module.exports = {
-  fetch
+  fetch,
+  Pusher,
 };

--- a/lib/isomorphic.js
+++ b/lib/isomorphic.js
@@ -1,11 +1,14 @@
+let fetch, Pusher;
+
 if (typeof window !== 'undefined') {
-  const fetch = window.fetch;
+  fetch = window.fetch;
 
   // we force loading from the web version to take advantage of proxy settings.
   // When under electron, the node version is normally loaded
-  const Pusher = require('pusher-js/dist/web/pusher')
+  Pusher = require('pusher-js/dist/web/pusher')
 } else {
-    const Pusher = require('pusher-js')
+  fetch = require('node-fetch')
+  Pusher = require('pusher-js')
 }
 
 module.exports = {

--- a/lib/isomorphic.js
+++ b/lib/isomorphic.js
@@ -1,0 +1,7 @@
+if (typeof window !== 'undefined') {
+  const fetch = window.fetch;
+}
+
+module.exports = {
+  fetch
+};

--- a/lib/isomorphic.js
+++ b/lib/isomorphic.js
@@ -1,7 +1,10 @@
-let fetch, Pusher;
+let fetch, Pusher, RTCPeerConnection;
 
 if (typeof window !== 'undefined') {
   fetch = window.fetch;
+
+  require('webrtc-adapter')
+  RTCPeerConnection = window.RTCPeerConnection;
 
   // we force loading from the web version to take advantage of proxy settings.
   // When under electron, the node version is normally loaded
@@ -9,9 +12,11 @@ if (typeof window !== 'undefined') {
 } else {
   fetch = require('node-fetch')
   Pusher = require('pusher-js')
+  RTCPeerConnection = require('wrtc').RTCPeerConnection
 }
 
 module.exports = {
   fetch,
   Pusher,
+  RTCPeerConnection,
 };

--- a/lib/peer-connection.js
+++ b/lib/peer-connection.js
@@ -1,4 +1,4 @@
-require('webrtc-adapter')
+const {RTCPeerConnection} = require('./isomorphic')
 
 const MAX_SEND_RETRY_COUNT = 5
 const MULTIPART_MASK = 0b00000001

--- a/lib/peer-pool.js
+++ b/lib/peer-pool.js
@@ -32,7 +32,7 @@ class PeerPool {
       const timeoutError = new Errors.PubSubConnectionError('Timed out while subscribing to incoming signals')
       this.listenPromise = new Promise(async (resolve, reject) => {
         let rejected = false
-        const timeoutId = window.setTimeout(() => {
+        const timeoutId = setTimeout(() => {
           this.listenPromise = null
           reject(timeoutError)
           rejected = true
@@ -46,7 +46,7 @@ class PeerPool {
         if (rejected) {
           subscription.dispose()
         } else {
-          window.clearTimeout(timeoutId)
+          clearTimeout(timeoutId)
           this.subscriptions.add(subscription)
           resolve(subscription)
         }

--- a/lib/pusher-pub-sub-gateway.js
+++ b/lib/pusher-pub-sub-gateway.js
@@ -1,4 +1,4 @@
-const Pusher = require('pusher-js/dist/web/pusher')
+const {Pusher} = require('./isomorphic')
 const {Disposable} = require('event-kit')
 const Errors = require('./errors')
 

--- a/lib/rest-gateway.js
+++ b/lib/rest-gateway.js
@@ -30,7 +30,7 @@ class RestGateway {
     const url = this.getAbsoluteURL(relativeURL)
     let response
     try {
-      response = await window.fetch(url, {method, headers, body})
+      response = await fetch(url, {method, headers, body})
     } catch (e) {
       const error = new HTTPRequestError('Connection failure')
       error.diagnosticMessage = getDiagnosticMessage({method, url})

--- a/lib/rest-gateway.js
+++ b/lib/rest-gateway.js
@@ -1,4 +1,5 @@
 const {HTTPRequestError} = require('./errors')
+const {fetch} = require('./isomorphic')
 
 module.exports =
 class RestGateway {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@atom/teletype-crdt": "^0.9.0",
     "event-kit": "^2.3.0",
     "google-protobuf": "^3.5.0",
+    "node-fetch": "^2.1.2",
     "pusher-js": "^4.2.2",
     "uuid": "^3.2.1",
     "webrtc-adapter": "~6.1"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "node-fetch": "^2.1.2",
     "pusher-js": "^4.2.2",
     "uuid": "^3.2.1",
-    "webrtc-adapter": "~6.1"
+    "webrtc-adapter": "~6.1",
+    "wrtc": "^0.1.5"
   },
   "devDependencies": {
     "@atom/teletype-server": "^0.18.1",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "electron-mocha **/*.test.js --ui=tdd --renderer --enable-experimental-web-platform-features",
+    "test:node": "mocha **/*.test.js --ui=tdd",
     "compile-protobuf": "protoc --js_out=import_style=commonjs,binary:lib teletype-client.proto teletype-crdt.proto"
   },
   "author": "",

--- a/test/helpers/timeout.js
+++ b/test/helpers/timeout.js
@@ -1,4 +1,4 @@
 module.exports =
 function timeout (ms) {
-  return new Promise((resolve) => window.setTimeout(resolve, ms))
+  return new Promise((resolve) => setTimeout(resolve, ms))
 }

--- a/test/teletype-client.test.js
+++ b/test/teletype-client.test.js
@@ -3,6 +3,10 @@ const assert = require('assert')
 const Errors = require('../lib/errors')
 const TeletypeClient = require('../lib/teletype-client')
 
+if (typeof ErrorEvent === 'undefined') {
+  ErrorEvent = Error;
+}
+
 suite('TeletypeClient', () => {
   suite('initialize', () => {
     test('throws when the protocol version is out of date according to the server', async () => {


### PR DESCRIPTION
fixes #53

this allows teletype-client to run without being within an Electron environment.

I'm unsure on the approach I've taken here. feedback welcome. If we need to handle
dependencies a different way, let me know.